### PR TITLE
Reduce watchtower block cache depth and increase target block time for compose configuration

### DIFF
--- a/atomizer-compose.cfg
+++ b/atomizer-compose.cfg
@@ -14,3 +14,5 @@ sentinel0_endpoint="sentinel0:7555"
 watchtower_count=1
 watchtower0_client_endpoint="watchtower0:8555"
 watchtower0_internal_endpoint="watchtower0:8556"
+watchtower_block_cache_size=50
+target_block_interval=3000


### PR DESCRIPTION
When using the docker compose configuration for the atomizer architecture, the default watchtower block cache depth results in docker killing the watchtower executable, presumably because the pre-allocation exceeds some docker-internal limit (see: https://github.com/mit-dci/opencbdc-tx/blob/trunk/src/uhs/atomizer/watchtower/block_cache.cpp#L12). This prevents the compose stack from starting successfully.

This is the output with the existing configuration file:
```
root@4faf91e6c24f:/opt/tx-processor# ./build/src/uhs/atomizer/watchtower/watchtowerd atomizer-compose.cfg 0
Killed
```

To reduce the memory allocation in the watchtower, this PR reduces the block cache depth to 50 blocks. It also increases the target block time to 3 seconds. This gives 150s before blocks are evicted from the cache, which should be plenty of time to run sync from the client.