### PR TITLE
Retry joining followers to raft clusters indefinitely

### DIFF
--- a/src/uhs/atomizer/atomizer/atomizer_raft.cpp
+++ b/src/uhs/atomizer/atomizer/atomizer_raft.cpp
@@ -15,7 +15,8 @@ namespace cbdc::atomizer {
                                  const network::endpoint_t& raft_endpoint,
                                  size_t stxo_cache_depth,
                                  std::shared_ptr<logging::log> logger,
-                                 nuraft::cb_func::func_type raft_callback)
+                                 nuraft::cb_func::func_type raft_callback,
+                                 bool wait_for_followers)
         : node(static_cast<int>(atomizer_id),
                raft_endpoint,
                m_node_type,
@@ -25,7 +26,8 @@ namespace cbdc::atomizer {
                    "atomizer_snps_" + std::to_string(atomizer_id)),
                0,
                std::move(logger),
-               std::move(raft_callback)) {}
+               std::move(raft_callback),
+               wait_for_followers) {}
 
     auto atomizer_raft::get_sm() -> state_machine* {
         auto* cls = dynamic_cast<state_machine*>(node::get_sm());

--- a/src/uhs/atomizer/atomizer/atomizer_raft.hpp
+++ b/src/uhs/atomizer/atomizer/atomizer_raft.hpp
@@ -26,11 +26,15 @@ namespace cbdc::atomizer {
         /// \param stxo_cache_depth number of blocks in the spent output cache.
         /// \param logger log instance.
         /// \param raft_callback NuRaft callback for raft events.
+        /// \param wait_for_followers true if the leader raft node should
+        ///                           re-attempt to add all followers to the
+        ///                           cluster until success.
         atomizer_raft(uint32_t atomizer_id,
                       const network::endpoint_t& raft_endpoint,
                       size_t stxo_cache_depth,
                       std::shared_ptr<logging::log> logger,
-                      nuraft::cb_func::func_type raft_callback);
+                      nuraft::cb_func::func_type raft_callback,
+                      bool wait_for_followers);
 
         /// Serialize and replicate the given request in the atomizer raft
         /// cluster. Return the response asynchonrously via the given result

--- a/src/uhs/atomizer/atomizer/controller.cpp
+++ b/src/uhs/atomizer/atomizer/controller.cpp
@@ -20,15 +20,16 @@ namespace cbdc::atomizer {
         : m_atomizer_id(atomizer_id),
           m_opts(opts),
           m_logger(std::move(log)),
-          m_raft_node(static_cast<uint32_t>(atomizer_id),
-                      opts.m_atomizer_raft_endpoints[atomizer_id].value(),
-                      m_opts.m_stxo_cache_depth,
-                      m_logger,
-                      [&](auto&& type, auto&& param) {
-                          return raft_callback(
-                              std::forward<decltype(type)>(type),
-                              std::forward<decltype(param)>(param));
-                      }) {}
+          m_raft_node(
+              static_cast<uint32_t>(atomizer_id),
+              opts.m_atomizer_raft_endpoints[atomizer_id].value(),
+              m_opts.m_stxo_cache_depth,
+              m_logger,
+              [&](auto&& type, auto&& param) {
+                  return raft_callback(std::forward<decltype(type)>(type),
+                                       std::forward<decltype(param)>(param));
+              },
+              m_opts.m_wait_for_followers) {}
 
     controller::~controller() {
         m_raft_node.stop();

--- a/src/uhs/twophase/coordinator/controller.cpp
+++ b/src/uhs/twophase/coordinator/controller.cpp
@@ -35,7 +35,8 @@ namespace cbdc::coordinator {
               [&](auto&& res, auto&& err) {
                   return raft_callback(std::forward<decltype(res)>(res),
                                        std::forward<decltype(err)>(err));
-              }),
+              },
+              m_opts.m_wait_for_followers),
           m_shard_endpoints(m_opts.m_locking_shard_endpoints),
           m_shard_ranges(m_opts.m_shard_ranges),
           m_batch_size(m_opts.m_batch_size),

--- a/src/uhs/twophase/locking_shard/controller.cpp
+++ b/src/uhs/twophase/locking_shard/controller.cpp
@@ -43,7 +43,8 @@ namespace cbdc::locking_shard {
               [&](auto&& res, auto&& err) {
                   return raft_callback(std::forward<decltype(res)>(res),
                                        std::forward<decltype(err)>(err));
-              })) {}
+              },
+              m_opts.m_wait_for_followers)) {}
 
     auto controller::init() -> bool {
         auto params = nuraft::raft_params();

--- a/src/util/common/config.cpp
+++ b/src/util/common/config.cpp
@@ -544,6 +544,10 @@ namespace cbdc::config {
 
         opts.m_batch_size
             = cfg.get_ulong(batch_size_key).value_or(opts.m_batch_size);
+        auto wait_for_followers = cfg.get_ulong(wait_for_followers_key);
+        if(wait_for_followers.has_value()) {
+            opts.m_wait_for_followers = wait_for_followers.value() != 0;
+        }
     }
 
     void read_loadgen_options(options& opts, const parser& cfg) {

--- a/src/util/common/config.hpp
+++ b/src/util/common/config.hpp
@@ -56,6 +56,7 @@ namespace cbdc::config {
         static constexpr size_t initial_mint_value{100};
         static constexpr size_t watchtower_block_cache_size{100};
         static constexpr size_t watchtower_error_cache_size{1000000};
+        static constexpr bool wait_for_followers{true};
 
         static constexpr auto log_level = logging::log_level::warn;
     }
@@ -113,6 +114,7 @@ namespace cbdc::config {
     static constexpr auto loadgen_count_key = "loadgen_count";
     static constexpr auto shard_completed_txs_cache_size
         = "shard_completed_txs_cache_size";
+    static constexpr auto wait_for_followers_key = "wait_for_followers";
 
     /// [start, end] inclusive.
     using shard_range_t = std::pair<uint8_t, uint8_t>;
@@ -239,6 +241,10 @@ namespace cbdc::config {
 
         /// Number of load generators over which to split pre-seeded UTXOs.
         size_t m_loadgen_count{0};
+
+        /// Flag for whether the raft leader should re-attempt to join
+        /// followers to the cluster until successful.
+        bool m_wait_for_followers{defaults::wait_for_followers};
     };
 
     /// Read options from the given config file without checking invariants.

--- a/src/util/raft/node.hpp
+++ b/src/util/raft/node.hpp
@@ -52,6 +52,9 @@ namespace cbdc::raft {
         ///                              of cores on the system.
         /// \param logger log instance NuRaft should use.
         /// \param raft_cb NuRaft callback to report raft events.
+        /// \param wait_for_followers true if the leader raft node should
+        ///                           re-attempt to add all followers to the
+        ///                           cluster until success.
         node(int node_id,
              const network::endpoint_t& raft_endpoint,
              const std::string& node_type,
@@ -59,7 +62,8 @@ namespace cbdc::raft {
              nuraft::ptr<nuraft::state_machine> sm,
              size_t asio_thread_pool_size,
              std::shared_ptr<logging::log> logger,
-             nuraft::cb_func::func_type raft_cb);
+             nuraft::cb_func::func_type raft_cb,
+             bool wait_for_followers);
 
         ~node();
 
@@ -128,6 +132,8 @@ namespace cbdc::raft {
 
         nuraft::asio_service::options m_asio_opt;
         nuraft::raft_server::init_options m_init_opts;
+
+        bool m_wait_for_followers;
 
         [[nodiscard]] auto add_cluster_nodes(
             const std::vector<network::endpoint_t>& raft_servers) const

--- a/tests/unit/raft_test.cpp
+++ b/tests/unit/raft_test.cpp
@@ -134,7 +134,8 @@ class raft_test : public ::testing::Test {
                                                    sm,
                                                    10,
                                                    log,
-                                                   nullptr));
+                                                   nullptr,
+                                                   false));
             sms.emplace_back(sm);
         }
 


### PR DESCRIPTION
This PR adds a retry loop to the initial raft cluster setup phase executed by leaders. Previously, followers would already have to be running before the leader (node 0 in a cluster) could be started. Otherwise, the leader would fail to add all the follower nodes to the raft cluster and abort. While this was useful for testing and benchmarking, it is undesirable in a deployment environment as node startup order is hard to guarantee. Instead, the leader now retries adding followers to the raft cluster until all followers have been added.