### PR TITLE
build: Check for buildtime support of cpu features

### DIFF
--- a/3rdparty/crypto/CMakeLists.txt
+++ b/3rdparty/crypto/CMakeLists.txt
@@ -7,12 +7,26 @@ add_library(crypto sha256_avx2.cpp
                    sha256.cpp
                    siphash.cpp)
 target_include_directories(crypto PRIVATE ".." ".")
-set_source_files_properties(sha256_avx2.cpp PROPERTIES COMPILE_FLAGS
-                                            "-DENABLE_AVX2 -mavx -mavx2")
-set_source_files_properties(sha256_shani.cpp PROPERTIES COMPILE_FLAGS
-                                             "-DENABLE_SHANI -msse4 -msha")
-set_source_files_properties(sha256_sse41.cpp PROPERTIES COMPILE_FLAGS
-                                             "-DENABLE_SSE41 -msse4.1")
-set_source_files_properties(sha256.cpp PROPERTIES COMPILE_FLAGS
-                                       "-DUSE_ASM -DENABLE_SHANI \
-                                       -DENABLE_SSE41 -DENABLE_AVX2")
+
+if (USE_AVX2)
+set_property(SOURCE sha256.cpp APPEND PROPERTY COMPILE_DEFINITIONS "ENABLE_AVX2")
+set_source_files_properties(sha256_avx2.cpp PROPERTIES
+                                            COMPILE_DEFINITIONS "ENABLE_AVX2"
+                                            COMPILE_FLAGS "${AVX2_CXXFLAGS}")
+endif()
+
+if (USE_SHANI)
+set_property(SOURCE sha256.cpp APPEND PROPERTY COMPILE_DEFINITIONS "ENABLE_SHANI")
+set_source_files_properties(sha256_shani.cpp PROPERTIES
+                                             COMPILE_DEFINITIONS "ENABLE_SHANI"
+                                             COMPILE_FLAGS "${SHANI_CXXFLAGS}")
+endif()
+
+if (USE_SSE41)
+set_property(SOURCE sha256.cpp APPEND PROPERTY COMPILE_DEFINITIONS "ENABLE_SSE41")
+set_source_files_properties(sha256_sse41.cpp PROPERTIES
+                                             COMPILE_DEFINITIONS "ENABLE_SSE41"
+                                             COMPILE_FLAGS "${SSE41_CXXFLAGS}")
+endif()
+
+set_property(SOURCE sha256.cpp APPEND PROPERTY COMPILE_DEFINITIONS "USE_ASM")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ try_compile(USE_STDFS_LIB ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/cmake-tests/t
 check_cxx_compiler_flag(-Wshadow-all W_SHADOW_ALL)
 check_cxx_compiler_flag(-Wnewline-eof W_NEWLINE_EOF)
 
+
+set(SSE41_CXXFLAGS "-msse4.1")
+set(AVX2_CXXFLAGS  "-mavx -mavx2")
+set(SHANI_CXXFLAGS "-msse4 -msha")
+
+try_compile(USE_SSE41 ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/cmake-tests/test-sse41.cpp" COMPILE_DEFINITIONS ${SSE41_CXXFLAGS})
+try_compile(USE_AVX2  ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/cmake-tests/test-avx2.cpp"  COMPILE_DEFINITIONS ${AVX2_CXXFLAGS})
+try_compile(USE_SHANI ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/cmake-tests/test-shani.cpp" COMPILE_DEFINITIONS ${SHANI_CXXFLAGS})
+
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/cmake-tests/test-avx2.cpp
+++ b/cmake-tests/test-avx2.cpp
@@ -1,0 +1,7 @@
+#include <immintrin.h>
+#include <stdint.h>
+
+int main() {
+    __m256i l = _mm256_set1_epi32(0);
+    return _mm256_extract_epi32(l, 7);
+}

--- a/cmake-tests/test-shani.cpp
+++ b/cmake-tests/test-shani.cpp
@@ -1,0 +1,8 @@
+#include <immintrin.h>
+#include <stdint.h>
+int main() {
+    __m128i i = _mm_set1_epi32(0);
+    __m128i j = _mm_set1_epi32(1);
+    __m128i k = _mm_set1_epi32(2);
+    return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, i, k), 0);
+}

--- a/cmake-tests/test-sse41.cpp
+++ b/cmake-tests/test-sse41.cpp
@@ -1,0 +1,6 @@
+#include <immintrin.h>
+#include <stdint.h>
+int main() {
+    __m128i l = _mm_set1_epi32(0);
+    return _mm_extract_epi32(l, 3);
+}


### PR DESCRIPTION
Addresses #42, though libsecp256k1 could use some feature detection as well. I suspect build is currently broken for 32bit targets.

Additionally, tests should be added for sse42 and crc for leveldb, but I don't believe their absence is causing any current build problems.