### PR TITLE
Align NuRaft version Dockerfile with configure.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update && \
 # Args
 ARG CMAKE_BUILD_TYPE="Release"
 ARG LEVELDB_VERSION="1.22"
-ARG NURAFT_VERSION="1.2.0"
+ARG NURAFT_VERSION="1.3.0"
 
 # Install LevelDB
 RUN wget https://github.com/google/leveldb/archive/${LEVELDB_VERSION}.tar.gz && \


### PR DESCRIPTION
The NuRaft version used in `scripts/configure.sh` when building locally is 1.3.0 presently.

However, when building using Docker we're using NuRaft version 1.2.0 as specified in the `Dockerfile`

While it doesn't seem to influence the ability to produce working binaries inside the Docker build system, I think we should make these two versions equal such that the binaries created in the Docker environment are the same as local builds.