### PR TITLE
Run make commands in Docker on all cores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget https://github.com/google/leveldb/archive/${LEVELDB_VERSION}.tar.gz && 
     rm -f ${LEVELDB_VERSION}.tar.gz && \
     cd leveldb-${LEVELDB_VERSION} && \
     cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 . && \
-    make && \
+    make -j$(nproc) && \
     make install
 
 # Install NuRaft
@@ -37,7 +37,7 @@ RUN wget https://github.com/eBay/NuRaft/archive/v${NURAFT_VERSION}.tar.gz && \
     mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 .. && \
-    make static_lib && \
+    make -j$(nproc) static_lib && \
     cp libnuraft.a /usr/local/lib && \
     cp -r ../include/libnuraft /usr/local/include
 
@@ -54,4 +54,4 @@ RUN git submodule init && git submodule update
 RUN mkdir build && \
     cd build && \
     cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} .. && \
-    make
+    make -j$(nproc)


### PR DESCRIPTION
In the regular build script `scripts/build.sh` we utilize the maximum number of cores when building by adding the `-j {cores}` argument. This is not present in the `Dockerfile`, which causes the Docker build to be unnecessarily slow - especially on systems that have a lot of cores.

This change will utilize the available number of cores when building.

On my machine (Ryzen 9 3900X) , this makes a huge difference:

Before:
```
real	4m54,257s
user	0m0,099s
sys	0m0,103s
```

After:
```
real	1m21,746s
user	0m0,087s
sys	0m0,069s
```