### PR TITLE
Add missing cbdc::atomizer::request

### DIFF
--- a/tools/bench/atomizer-cli-watchtower.cpp
+++ b/tools/bench/atomizer-cli-watchtower.cpp
@@ -266,7 +266,8 @@ auto main(int argc, char** argv) -> int {
                     for(auto&& tx : retry_txs) {
                         auto resend_pkt
                             = send_tx_to_atomizer(tx, best_watchtower_height);
-                        if(!atomizer_network.send_to_one(resend_pkt)) {
+                        if(!atomizer_network.send_to_one(
+                               cbdc::atomizer::request{resend_pkt})) {
                             log->error("Failed to resend tx to atomizer.");
                         }
                         rebroadcast++;
@@ -510,7 +511,8 @@ auto main(int argc, char** argv) -> int {
             auto send_pkt
                 = send_tx_to_atomizer(cbdc::transaction::compact_tx(pay_tx),
                                       best_height);
-            if(!atomizer_network.send_to_one(send_pkt)) {
+            if(!atomizer_network.send_to_one(
+                   cbdc::atomizer::request{send_pkt})) {
                 log->info("Failed to send pay tx to atomizer. ID:",
                           cbdc::to_string(cbdc::transaction::tx_id(pay_tx)),
                           "h:",


### PR DESCRIPTION
In the `atomizer-cli-watchtower`, when testing without signing, the transactions are directly delivered to the atomizer. However, in 2/3 cases the request isn't wrapped in a `cbdc::atomizer::request{}` as introduced [here](https://github.com/mit-dci/opencbdc-tx/commit/8db8be1d5ce93066917932734f908e01596f03f1)

Without this fix, the atomizer is reporting

```Invalid request packet```

And the `atomizer-cli-watchtower` is reporting: 

```Failed to send pay tx to atomizer. ID:{tx id} h:{height}```