### PR TITLE
Removed extraneous \return command for Doxygen

### DIFF
--- a/src/uhs/atomizer/watchtower/error_cache.hpp
+++ b/src/uhs/atomizer/watchtower/error_cache.hpp
@@ -34,7 +34,6 @@ namespace cbdc::watchtower {
         /// Moves an error into the error cache, evicting the oldest error if
         /// the cache has reached its maximum size.
         /// \param errs the error to move.
-        /// \return true if error was successfully added to cache. False if error is invalid and not added to cache.
         void push_errors(std::vector<tx_error>&& errs);
 
         /// Checks the cache for an error associated with the given Tx ID.

--- a/src/uhs/transaction/wallet.hpp
+++ b/src/uhs/transaction/wallet.hpp
@@ -150,7 +150,6 @@ namespace cbdc::transaction {
         /// \param value the value to use for the seeded outputs.
         /// \param begin_seed the start index to use for the seeded outputs.
         /// \param end_seed the end index to use for the seeded outputs.
-        /// \return true if setting the seed parameters succeeded.
         void seed_readonly(const hash_t& witness_commitment,
                            uint32_t value,
                            size_t begin_seed,


### PR DESCRIPTION
Very minor fix for #52.  All tests passed.  Full Doxygen run log attached
[out.txt](https://github.com/mit-dci/opencbdc-tx/files/8054874/out.txt)
.