### PR TITLE
Add docs to readme.md for running test suite in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update && \
       libgtest-dev \
       libgmock-dev \
       net-tools \
+      lcov \
       git
 
 # Args

--- a/README.md
+++ b/README.md
@@ -139,3 +139,16 @@ In each of the below commands, you should pass `atomizer-compose.cfg` instead of
   # ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool1.dat wallet1.dat info
   Balance: $0.30, UTXOs: 1, pending TXs: 0
   ```
+
+## Testing
+
+Running Unit & Integration Tests
+
+1. Build the container
+   ```terminal
+   # docker build . -t opencbdc-tx
+   ```
+2. Run Unit & Integration Tests
+   ```terminal
+   # docker run -ti opencbdc-tx ./scripts/test.sh
+   ```


### PR DESCRIPTION
- Add docs for running the test suite in docker for enabling contributors to test their code prior to submitting
- Add `lcov` to base `Dockerfile` as a dependency so tests that run in the docker container can produce code coverage metrics