### PR TITLE
Calculate size of object and allocate before serialization

### DIFF
--- a/src/util/serialization/util.hpp
+++ b/src/util/serialization/util.hpp
@@ -32,9 +32,9 @@ namespace cbdc {
     template<typename T, typename B = buffer>
     auto make_buffer(const T& obj)
         -> std::enable_if_t<std::is_same_v<B, buffer>, cbdc::buffer> {
-        // TODO: we could use serialized_size to preallocate the buffer which
-        //       could improve performance.
+        auto sz = serialized_size(obj);
         auto pkt = cbdc::buffer();
+        pkt.extend(sz);
         auto ser = cbdc::buffer_serializer(pkt);
         ser << obj;
         return pkt;
@@ -46,7 +46,9 @@ namespace cbdc {
     /// \return a shared_ptr to a serialized buffer of the object.
     template<typename T>
     auto make_shared_buffer(const T& obj) -> std::shared_ptr<cbdc::buffer> {
+        auto sz = serialized_size(obj);
         auto buf = std::make_shared<cbdc::buffer>();
+        buf->extend(sz);
         auto ser = cbdc::buffer_serializer(*buf);
         ser << obj;
         return buf;


### PR DESCRIPTION
This PR clears a TODO in the serialisation helpers. Pre-calculates the serialised size of the object and allocates the required memory in the buffer before performing the actual serialisation. This reduces the number of heap allocations to one per use of `make_buffer` or `make_shared_buffer`.