### PR TITLE
Support multiple consumers from blocking queue

### DIFF
--- a/src/util/common/blocking_queue.hpp
+++ b/src/util/common/blocking_queue.hpp
@@ -66,9 +66,8 @@ namespace cbdc {
                     item = std::move(m_buffer.front());
                     m_buffer.pop();
                     popped = true;
+                    m_wake = !m_buffer.empty();
                 }
-
-                m_wake = !m_buffer.empty();
 
                 return popped;
             }


### PR DESCRIPTION
This PR fixes `cbdc::blocking_queue` so that it can support multiple consumers popping from the queue. Prior to this change `pop()` would set the wake-up flag even if no element was popped from the queue. This prevented multiple consumers from unblocking after a `clear()` call.