### PR TITLE
Implement serialization for cbdc::buffer

### DIFF
--- a/src/util/serialization/format.cpp
+++ b/src/util/serialization/format.cpp
@@ -20,4 +20,18 @@ namespace cbdc {
 
         return packet;
     }
+
+    auto operator<<(serializer& ser, const buffer& b) -> serializer& {
+        ser << static_cast<uint64_t>(b.size());
+        ser.write(b.data(), b.size());
+        return ser;
+    }
+
+    auto operator>>(serializer& deser, buffer& b) -> serializer& {
+        uint64_t sz{};
+        deser >> sz;
+        b.extend(sz);
+        deser.read(b.data(), sz);
+        return deser;
+    }
 }

--- a/src/util/serialization/format.hpp
+++ b/src/util/serialization/format.hpp
@@ -7,6 +7,7 @@
 #define OPENCBDC_TX_SRC_SERIALIZATION_FORMAT_H_
 
 #include "serializer.hpp"
+#include "util/common/buffer.hpp"
 #include "util/common/config.hpp"
 #include "util/common/variant_overloaded.hpp"
 
@@ -33,6 +34,17 @@ namespace cbdc {
     ///
     /// \see \ref cbdc::operator<<(serializer&, std::byte)
     auto operator>>(serializer& packet, std::byte& b) -> serializer&;
+
+    /// \brief Serializes a raw byte buffer.
+    ///
+    /// Writes the size of the buffer as a 64-bit uint, followed by the actual
+    /// buffer data.
+    ///
+    /// \see \ref cbdc::operator>>(serializer&, buffer&)
+    auto operator<<(serializer& ser, const buffer& b) -> serializer&;
+
+    /// \brief Deserializes a raw byte buffer.
+    auto operator>>(serializer& deser, buffer& b) -> serializer&;
 
     /// Serializes nothing if `T` is an empty type.
     /// \tparam T an empty type


### PR DESCRIPTION
This PR implements serialisation for `cbdc::buffer`. The size is serialised first (as a 64-bit unit), followed by the actual buffer data.