### PR TITLE
Expose parse_ip_port function from config namespace

### DIFF
--- a/src/util/common/config.cpp
+++ b/src/util/common/config.cpp
@@ -11,6 +11,7 @@
 
 namespace cbdc::config {
     auto parse_ip_port(const std::string& in_str) -> network::endpoint_t {
+        // TODO: error handling for string parsing
         std::istringstream ss(in_str);
 
         std::string host;

--- a/src/util/common/config.hpp
+++ b/src/util/common/config.hpp
@@ -379,6 +379,8 @@ namespace cbdc::config {
 
         std::map<std::string, value_t> m_options;
     };
+
+    auto parse_ip_port(const std::string& in_str) -> network::endpoint_t;
 }
 
 #endif // OPENCBDC_TX_SRC_COMMON_CONFIG_H_


### PR DESCRIPTION
This PR exposes the `parse_ip_port` function used by the configuration parser so that it can be used outside of that context. Also adds a TODO for error handling, given the function currently requires a correctly parseable string as input.