### PR TITLE
Simplify shard seeder tool to use config file

### DIFF
--- a/src/uhs/twophase/locking_shard/controller.cpp
+++ b/src/uhs/twophase/locking_shard/controller.cpp
@@ -22,10 +22,12 @@ namespace cbdc::locking_shard {
           m_logger(std::move(logger)),
           m_shard_id(shard_id),
           m_node_id(node_id),
-          m_preseed_dir(m_opts.m_seed_from != m_opts.m_seed_to
-                            ? "shard_preseed_" + std::to_string(m_shard_id)
-                                  + "_" + std::to_string(m_node_id)
-                            : ""),
+          m_preseed_dir(
+              m_opts.m_seed_from != m_opts.m_seed_to
+                  ? "2pc_shard_preseed_"
+                        + std::to_string(m_opts.m_seed_to - m_opts.m_seed_from)
+                        + "_" + std::to_string(m_shard_id)
+                  : ""),
           m_state_machine(nuraft::cs_new<state_machine>(
               m_opts.m_shard_ranges[m_shard_id],
               m_logger,


### PR DESCRIPTION
This PR simplifies the shard seeder tool usage. Rather than using command line options, use the configuration file to determine pre-seed generation parameters. Also unifies the file names generated by the shard seeder with those expected by the shards themselves when loading the pre-seed.