### PR TITLE
Add support for doxygen CI deployments to gh-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Doxygen Deployment
+
+on:
+  push:
+    branches:
+      - trunk
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  gh-pages-deploy:
+    name: Github Pages Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Run Doxygen
+        uses: mattnotmitt/doxygen-action@1.9.3
+        with:
+          working-directory: .
+          doxyfile-path: ./Doxyfile
+          enable-latex: false
+          additional-packages: graphviz
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doxygen_generated/html

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,7 @@
 * The [Project Readme](/README.md) includes a crash-course for getting setup with the code and running a few tests
 * The [Contribution Guide](contributing.md) includes more thorough discussion of the project's guiding principles, governance model, and how to get involved
 * The [Technical Reference](https://mit-dci.github.io/opencbdc-tx/) includes documentation for the code itself and how it works
+* Code immediately merged may take a few minutes to go live as the docs get generated and page cache is cleared
 * The [Architecture Guide](architecture.md) walks through the data model of transactions and the currently-implemented architectures
 * The [Contribution Lifecycle Guide](lifecycle.md) takes you through what you can expect throughout the process of submitting a contribution to OpenCBDC
 


### PR DESCRIPTION
Add support for doxygen CI deployments to gh-pages
closes #51
Signed-off-by: Jonathan Allen <jonathan.allen@bos.frb.org>