### PR TITLE
Fixes failure for network::tcp_listener::listen() appearing not to fail when binding to invalid endpoint

### DIFF
--- a/tests/unit/archiver_test.cpp
+++ b/tests/unit/archiver_test.cpp
@@ -178,14 +178,17 @@ TEST_F(ArchiverTest, archiver_server_init) {
     ASSERT_TRUE(m_archiver->init_archiver_server());
 }
 
-// TODO: cbdc::network::tcp_listener::listen() does not fail to bind to an
-// invalid endpoint, causing this test to fail.
-/*TEST_F(ArchiverTest, archiver_server_init_failure) {
-    cbdc::network::endpoint_t invalid_endpoint = {"invalid-endpoint",5000};
+TEST_F(ArchiverTest, archiver_server_init_failure) {
+    cbdc::network::endpoint_t invalid_endpoint = {"invalid-endpoint", 5000};
     m_config_opts.m_archiver_endpoints.clear();
     m_config_opts.m_archiver_endpoints.emplace_back(invalid_endpoint);
-    ASSERT_FALSE(m_archiver->init_archiver_server());
-}*/
+    std::unique_ptr<cbdc::archiver::controller> m_archiver_invalid_endpoint
+        = std::make_unique<cbdc::archiver::controller>(0,
+                                                       m_config_opts,
+                                                       m_log,
+                                                       0);
+    ASSERT_FALSE(m_archiver_invalid_endpoint->init_archiver_server());
+}
 
 // Test if the archiver properly digests a block
 TEST_F(ArchiverTest, digest_block) {


### PR DESCRIPTION
Creating PR to fix issue #11, 

from the commit message 3f4ebe9fa8296542158ff505b47fd8f277e313dd:

The archiver test "archiver_server_init_failure" failed beforehand, which made it seem
as if connecting to an invalid endpoint still allowed the server to be initialized. Turns
out that the test was the problem. The test used to edit m_config_opts, however m_config_opts
did not get changed inside m_archiver, since m_config_opts was copied into m_archiver during
initialization, not referenced to it. Now the test has a new m_archiver that has the m_config_opts
variable changes ever since initialization, allowing test to fail to bind to it.

Created a new m_archiver_invalid_endpoint variable to be able to add the edited variable
that has the invalid endpoint on it. Have to create new m_archiver_invalid_endpoint
variable because editing the vector that includes the invalid endpoint does not work since
a copy of the vector gets passed down according to controller initializer, not a reference of it.

closes #11 