### PR TITLE
Don't import inputs not sent to the current wallet

### DIFF
--- a/src/uhs/client/client.cpp
+++ b/src/uhs/client/client.cpp
@@ -165,8 +165,12 @@ namespace cbdc {
     }
 
     void client::import_send_input(const transaction::input& in) {
-        m_pending_inputs.insert({in.m_prevout.m_tx_id, in});
-        save();
+        if(m_wallet.is_spendable(in)) {
+            m_pending_inputs.insert({in.m_prevout.m_tx_id, in});
+            save();
+        } else {
+            m_logger->warn("Ignoring non-spendable input");
+        }
     }
 
     auto client::new_address() -> pubkey_t {

--- a/src/uhs/transaction/wallet.cpp
+++ b/src/uhs/transaction/wallet.cpp
@@ -532,4 +532,16 @@ namespace cbdc {
         }
         return {{ret, total_amount}};
     }
+
+    auto transaction::wallet::is_spendable(const transaction::input& in) const
+        -> bool {
+        const auto& in_key = in.m_prevout_data.m_witness_program_commitment;
+        bool key_ours = false;
+        {
+            std::shared_lock<std::shared_mutex> sl(m_keys_mut);
+            const auto wit_prog = m_witness_programs.find(in_key);
+            key_ours = wit_prog != m_witness_programs.end();
+        }
+        return key_ours;
+    }
 }

--- a/src/uhs/transaction/wallet.hpp
+++ b/src/uhs/transaction/wallet.hpp
@@ -172,6 +172,10 @@ namespace cbdc::transaction {
         /// \param tx the transaction whose inputs to sign.
         void sign(full_tx& tx) const;
 
+        /// Checks if the input is spendable by the current wallet.
+        /// \param in the input to check.
+        auto is_spendable(const input& in) const -> bool;
+
         /// Returns the total balance of the wallet, e.g. the sum total value
         /// of all the UTXOs this wallet contains.
         /// \return the wallet balance in the base unit of the currency.


### PR DESCRIPTION
Hi,

I took at swing at fixing #54. I did this by mirroring how a similar check is done in `transaction::wallet::sign`. I thought about splitting it off into a common method that could be both places, but I didn't want to mess with the other operations done with the lock in the `sign` method.

The new output from the steps shown in the issue is:

```
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool0.dat wallet0.dat mint 1 1
[2022-03-15 04:41:34.807] [WARN ] Existing wallet file not found
[2022-03-15 04:41:34.807] [WARN ] Existing client file not found
040e6a5e3e0b7ed30a61696693ace87abb7444e0fe9bb0fa34208f52a0dcb40a
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool1.dat wallet1.dat newaddress
[2022-03-15 04:41:39.851] [WARN ] Existing wallet file not found
[2022-03-15 04:41:39.851] [WARN ] Existing client file not found
usd1qrefhljq2n73vyhc0vf85cack6685cze704qeqs32kjdhaku68yhcwnceqc
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool0.dat wallet0.dat send 1 usd1qrefhljq2n73vyhc0vf85cack6685cze704qeqs32kjdhaku68yhcwnceqc
tx_id:
a93ae49bc9e2bd50f1f231ec57a7928111568fb89bef1d38096ca6d2a835bc4c
Data for recipient importinput:
a93ae49bc9e2bd50f1f231ec57a7928111568fb89bef1d38096ca6d2a835bc4c00000000000000005a387c6a6eb9748158550430f1536efc993932936c603e72cc6dd26fb43a881c0100000000000000
Sentinel responded: Confirmed
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool1.dat wallet1.dat importinput a93ae49bc9e2bd50f1f231ec57a7928111568fb89bef1d38096ca6d2a835bc4c00000000000000005a387c6a6eb9748158550430f1536efc993932936c603e72cc6dd26fb43a881c0100000000000000
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool0.dat wallet0.dat importinput a93ae49bc9e2bd50f1f231ec57a7928111568fb89bef1d38096ca6d2a835bc4c00000000000000005a387c6a6eb9748158550430f1536efc993932936c603e72cc6dd26fb43a881c0100000000000000
[2022-03-15 04:42:27.411] [WARN ] Ignoring non-spendable input
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool1.dat wallet1.dat sync
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool0.dat wallet0.dat sync
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool1.dat wallet1.dat info
Balance: $0.01, UTXOs: 1, pending TXs: 0
root@9c5f6600cab3:/opt/tx-processor# ./build/src/uhs/client/client-cli 2pc-compose.cfg mempool0.dat wallet0.dat info
Balance: $0.00, UTXOs: 0, pending TXs: 0
```


Let me know what you think. I'm happy to make any needed changes if this seems like a plausible solution.

Thanks

Signed-off-by: Jon Wiggins <me@jonwiggins.org>