### PR TITLE
Adding a Github Actions Workflow to publish Docker images to Github C…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+---
+name: docker
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - trunk
+
+jobs:
+  docker-build-and-publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -62,26 +62,39 @@ The easiest way to compile the code and run the system locally is using [Docker]
 
 Don't forget to run the docker daemon!
 
-## Build the container
-
-```terminal
-$ cd opencbdc-tx                 # change to the project directory
-$ sudo -s                        # open a root shell (needed for docker)
-# docker build . -t opencbdc-tx  # build the container
-```
-
 ## Launch the System
 
 **Note:** You will need to both run the system and interact with it; you can either use two shells, or you can add the `--detach` flag when launching the system (note that it will then remain running till you stop it, e.g., with `docker stop`).
 Additionally, you can start the atomizer architecture by passing `--file docker-compose-atomizer.yml` instead.
 
+_The commands below will build a new image every time that you run it.
+You can remove the `--build` flag after the image has been built to avoid rebuilding.
+To run the system with our pre-built image proceed to the [next section](#launch-the-system-with-a-pre-built-image) for the commands to run._
+
 1. Run the System
    ```terminal
-   # docker-compose --file docker-compose-2pc.yml up
+   # docker compose --file docker-compose-2pc.yml up --build
    ```
 1. Launch a container in which to run wallet commands (use `--network atomizer-network` instead of `--network 2pc-network` if using the atomizer architecture)
    ```terminal
    # docker run --network 2pc-network -ti opencbdc-tx /bin/bash
+   ```
+
+## Launch the System With a Pre-built Image
+
+We publish new docker images for all commits to `trunk`.
+You can find the images [in the Github Container Registry](https://github.com/mit-dci/opencbdc-tx/pkgs/container/opencbdc-tx).
+
+**Note:** You must use `docker compose` (not `docker-compose`) for this approach to work or you will need to pull the image manually `docker pull ghcr.io/mit-dci/opencbdc-tx`.
+Additionally, you can start the atomizer architecture by passing `--file docker-compose-atomizer.yml --file docker-compose-prebuilt-atomizer.yml` instead.
+
+1. Run the system
+    ```terminal
+    # docker compose --file docker-compose-2pc.yml --file docker-compose-prebuilt-2pc.yml up --no-build
+    ```
+1. Launch a container in which to run wallet commands (use `--network atomizer-network` instead of `--network 2pc-network` if using the atomizer architecture)
+   ```terminal
+   # docker run --network 2pc-network -ti ghcr.io/mit-dci/opencbdc-tx /bin/bash
    ```
 
 ## Setup test wallets and test them

--- a/docker-compose-prebuilt-2pc.yml
+++ b/docker-compose-prebuilt-2pc.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  sentinel0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  coordinator0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  shard0:
+    image: ghcr.io/mit-dci/opencbdc-tx

--- a/docker-compose-prebuilt-atomizer.yml
+++ b/docker-compose-prebuilt-atomizer.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+
+  watchtower0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  atomizer0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  archiver0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  shard0:
+    image: ghcr.io/mit-dci/opencbdc-tx
+
+  sentinel0:
+    image: ghcr.io/mit-dci/opencbdc-tx


### PR DESCRIPTION
Adding a Github Actions Workflow to publish Docker images to Github Container Registry. Images will be published with the branch name, `latest` and commit sha only on the default branch. In this case every time a branch is merged into `trunk` there will be a new Docker image published with the tags `sha-<commit>`, `latest` and `trunk`.

This docker image can be pulled using the following:

```
docker pull ghcr.io/mit-dci/opencbdc-tx:latest
```

It can also be used in a downstream Docker image like this:

```
FROM ghcr.io/mit-dci/opencbdc-tx:latest
```

   -  I've added a new file called `docker-compose-prebuilt-2pc.yml` that only contains the image and build args necessary to make sure that docker compose will use a prebuilt image if this file is provided. Documentation has been updated with instructions.
        - The benefit of this change is that it will be significantly faster to get up and running with the system if you are not making any code changes.


Re-opening #76 
    Signed-off-by: Kyle Crawshaw <kyle.crawshaw@gmail.com>
