### PR TITLE
adjust scripts, Cmake for OSX. Updates README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ try_compile(USE_STDFS_LIB ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/cmake-tests/t
 check_cxx_compiler_flag(-Wshadow-all W_SHADOW_ALL)
 check_cxx_compiler_flag(-Wnewline-eof W_NEWLINE_EOF)
 
-
 set(SSE41_CXXFLAGS "-msse4.1")
 set(AVX2_CXXFLAGS  "-mavx -mavx2")
 set(SHANI_CXXFLAGS "-msse4 -msha")
@@ -35,12 +34,11 @@ find_library(NURAFT_LIBRARY nuraft REQUIRED)
 message("Disabling Run Time Type Information (RTTI) features.")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
-include_directories(3rdparty 3rdparty/secp256k1/include)
+include_directories(3rdparty 3rdparty/secp256k1/include /usr/local/include /opt/homebrew/include)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-fprofile-arcs -ftest-coverage)
 endif()
-
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_link_options(--coverage)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ For more information on how to contribute, please see our [Contribution Guide](d
 1. Clone the repository (including submodules)
     - `git clone --recurse-submodules https://github.com/mit-dci/opencbdc-tx`
 
+# Build
+
+Use these directions if you want to build the source on your machine.
+If you just want to run the system, see "Run the Code" below.
+
+## macOS
+Ensure your development environment is set correctly for clang:
+
+`sudo xcode-select -switch /Library/Developer/CommandLineTools`
+
+Or, if you've changed this in the past, you can reset to point to commandline tools with:
+
+`sudo xcode-select --reset`
+
+
+1. Install dependencies: `brew install leveldb llvm@11 googletest lcov make wget cmake`
+2. `./scripts/configure.sh`
+3. `./scripts/build.sh`
+
+Note: To run clang-tidy and clang-format (required by `lint.sh`), you must add them both to your path.
+
+Ex: `ln -s /usr/local/opt/llvm@11/bin/clang-tidy /usr/local/bin/clang-tidy`
+
+## Linux
+
+1. `./scripts/configure.sh`
+2. `./scripts/build.sh`
+
 # Run the Code
 
 The easiest way to compile the code and run the system locally is using [Docker](https://www.docker.com).

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,15 +10,14 @@ fi
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
-
-CPUS=1
 CMAKE_FLAGS=""
+CPUS=1
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     CPUS=$(grep -c ^processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPUS=$(sysctl -n hw.ncpu)
     XCODE_CMDLINE_DIR=$(xcode-select -p)
-    CMAKE_FLAGS+="-DCMAKE_MAKE_PROGRAM=/usr/local/bin/gmake -DCMAKE_C_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang -DCMAKE_CXX_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang++ -DCMAKE_CXX_FLAGS=-isystem\ /usr/local/include -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    CMAKE_FLAGS+="-DCMAKE_C_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang -DCMAKE_CXX_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang++ -DCMAKE_CXX_FLAGS=-isystem\ /usr/local/include -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
 CMAKE_BUILD_TYPE="Debug"

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -20,10 +20,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
 fi
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  brew install leveldb llvm@11 googletest lcov make
-  echo -e "${cyan}To run clang-tidy, you must add it to your path. Ex: ln -s /usr/local/opt/llvm@11/bin/clang-tidy /usr/local/bin/clang-tidy${end}"
-else
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   apt update
   apt install -y build-essential wget cmake libgtest-dev libgmock-dev lcov git software-properties-common
 
@@ -79,9 +76,14 @@ else
   cd "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}/build"
 fi
 
-cp libnuraft.a /usr/local/lib
-cp -r ../include/libnuraft /usr/local/include
+echo -e "${green}Copying nuraft to /usr/local. sudo needed${end}"
+sudo cp libnuraft.a /usr/local/lib
+sudo cp -r ../include/libnuraft /usr/local/include
 
 cd ..
 
-wget https://raw.githubusercontent.com/llvm/llvm-project/e837ce2a32369b2e9e8e5d60270c072c7dd63827/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -P /usr/local/bin
+PYTHON_TIDY=/usr/local/bin/run-clang-tidy.py
+if [ ! -f "${PYTHON_TIDY}" ]; then
+  echo -e "${green}Copying run-clang-tidy to /usr/local/bin. sudo needed${end}"
+  sudo wget https://raw.githubusercontent.com/llvm/llvm-project/e837ce2a32369b2e9e8e5d60270c072c7dd63827/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -P /usr/local/bin
+fi


### PR DESCRIPTION
Signed-off-by: Dave Bryson

Changes:
- Removed brew installs from configure.sh and added to build information in README.  Why? calling `sudo ./configure.sh` fails as brew can't be called with sudo
- Moved OSX specific CMAKE_FLAGS to CmakeFile.txt
- Added `build` information to README 

References: https://github.com/mit-dci/opencbdc-tx/issues/94 