### PR TITLE
Check the watchtower is syncing with the atomizer

### DIFF
--- a/src/uhs/atomizer/atomizer/controller.cpp
+++ b/src/uhs/atomizer/atomizer/controller.cpp
@@ -104,6 +104,8 @@ namespace cbdc::atomizer {
             });
         }
 
+        m_logger->info("Atomizer started...");
+
         return true;
     }
 
@@ -194,7 +196,7 @@ namespace cbdc::atomizer {
                               std::forward<decltype(r)>(r),
                               std::forward<decltype(err)>(err));
                       });
-                if(!res) {
+                if(!res && m_running) {
                     m_logger->error("Failed to make block at time",
                                     last_time.time_since_epoch().count());
                 }
@@ -263,6 +265,7 @@ namespace cbdc::atomizer {
             if(m_atomizer_server.joinable()) {
                 m_atomizer_server.join();
             }
+            m_logger->debug("Became follower, stopped listening");
         } else if(type == nuraft::cb_func::Type::BecomeLeader) {
             // We became the leader. Ensure the previous handler thread is
             // stopped and network shut down.
@@ -284,6 +287,7 @@ namespace cbdc::atomizer {
                 m_logger->fatal("Failed to establish atomizer server.");
             }
             m_atomizer_server = std::move(as.value());
+            m_logger->debug("Became leader, started listening");
         }
         return nuraft::cb_func::ReturnCode::Ok;
     }

--- a/src/uhs/atomizer/watchtower/controller.cpp
+++ b/src/uhs/atomizer/watchtower/controller.cpp
@@ -161,3 +161,7 @@ auto cbdc::watchtower::controller::external_server_handler(
     auto msg = std::visit(res_handler, req.payload());
     return msg;
 }
+
+auto cbdc::watchtower::controller::get_block_height() const -> uint64_t {
+    return m_last_blk_height;
+}

--- a/src/uhs/atomizer/watchtower/controller.hpp
+++ b/src/uhs/atomizer/watchtower/controller.hpp
@@ -36,13 +36,15 @@ namespace cbdc::watchtower {
         /// \return true if initialization succeeded.
         auto init() -> bool;
 
+        auto get_block_height() const -> uint64_t;
+
       private:
         uint32_t m_watchtower_id;
         cbdc::config::options m_opts;
         std::shared_ptr<logging::log> m_logger;
 
         watchtower m_watchtower;
-        uint64_t m_last_blk_height{0};
+        std::atomic<uint64_t> m_last_blk_height{0};
 
         cbdc::network::connection_manager m_internal_network;
         cbdc::network::connection_manager m_external_network;

--- a/tests/integration/atomizer_end_to_end_test.cpp
+++ b/tests/integration/atomizer_end_to_end_test.cpp
@@ -54,6 +54,9 @@ class atomizer_end_to_end_test : public ::testing::Test {
         ASSERT_TRUE(m_ctl_shard->init());
         ASSERT_TRUE(m_ctl_sentinel->init());
 
+        std::this_thread::sleep_for(m_block_wait_interval);
+        ASSERT_TRUE(m_ctl_watchtower->get_block_height() > 0);
+
         reload_sender();
         reload_receiver();
 
@@ -62,6 +65,8 @@ class atomizer_end_to_end_test : public ::testing::Test {
         m_sender->mint(10, 10);
         std::this_thread::sleep_for(m_block_wait_interval);
         m_sender->sync();
+
+        ASSERT_EQ(m_sender->balance(), 10 * 10);
 
         reload_sender();
 


### PR DESCRIPTION
If the watchtower fails to sync blocks from the atomizer in the end-to-end integration test, this was previously a silent failure. The tests would still fail but due to confusing side effects like transactions not being confirmed. This commit updates the test to explicitly check the watchtower is syncing blocks and that the mint transactions confirm. It also adds some log messages to components that were useful while investigating the issue that led to this PR.