### PR TITLE
Balance load across sentinels from load generators

### DIFF
--- a/src/util/network/connection_manager.cpp
+++ b/src/util/network/connection_manager.cpp
@@ -238,7 +238,14 @@ namespace cbdc::network {
         bool sent{false};
         {
             std::shared_lock<std::shared_mutex> l(m_peer_mutex);
-            for(const auto& p : m_peers) {
+            // Start at a random place in the peers vector to balance load
+            // across connections
+            auto dist
+                = std::uniform_int_distribution<size_t>(0, m_peers.size() - 1);
+            auto offset = dist(m_rnd);
+            for(size_t i = 0; i < m_peers.size(); i++) {
+                auto idx = (i + offset) % m_peers.size();
+                const auto& p = m_peers[idx];
                 if(p.m_peer->connected()) {
                     p.m_peer->send(data);
                     sent = true;

--- a/src/util/network/connection_manager.hpp
+++ b/src/util/network/connection_manager.hpp
@@ -16,6 +16,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <queue>
+#include <random>
 #include <shared_mutex>
 #include <sys/socket.h>
 #include <thread>
@@ -228,6 +229,11 @@ namespace cbdc::network {
         bool m_async_recv_data{false};
 
         socket_selector m_listen_selector;
+
+        std::default_random_engine m_rnd{
+            static_cast<uint32_t>(std::chrono::high_resolution_clock::now()
+                                      .time_since_epoch()
+                                      .count())};
     };
 }
 

--- a/tools/bench/atomizer-cli-watchtower.cpp
+++ b/tools/bench/atomizer-cli-watchtower.cpp
@@ -96,14 +96,12 @@ auto main(int argc, char** argv) -> int {
     auto sentinel_client = std::unique_ptr<cbdc::sentinel::rpc::client>();
 
     if(sign_txs) {
-        // TODO: sentinel load balancing
-        const auto our_sentinel = cli_id % cfg.m_sentinel_endpoints.size();
-        const auto sentinel_ep = cfg.m_sentinel_endpoints[our_sentinel];
+        // TODO: load balancing strategies other than round-robin, backpressure
         sentinel_client = std::make_unique<cbdc::sentinel::rpc::client>(
-            std::vector<cbdc::network::endpoint_t>({sentinel_ep}),
+            std::vector<cbdc::network::endpoint_t>(cfg.m_sentinel_endpoints),
             log);
         if(!sentinel_client->init()) {
-            log->error("Error connecting to sentinel");
+            log->error("Error connecting to sentinels");
             return -1;
         }
     }

--- a/tools/bench/twophase_gen.cpp
+++ b/tools/bench/twophase_gen.cpp
@@ -40,8 +40,6 @@ auto main(int argc, char** argv) -> int {
     auto sha2_impl = SHA256AutoDetect();
     logger->info("using sha2: ", sha2_impl);
 
-    auto our_sentinel = gen_id % cfg.m_sentinel_endpoints.size();
-
     auto engine = std::default_random_engine();
     auto invalid_dist = std::bernoulli_distribution(cfg.m_invalid_rate);
     auto fixed_dist = std::bernoulli_distribution(cfg.m_fixed_tx_rate);
@@ -118,8 +116,7 @@ auto main(int argc, char** argv) -> int {
     }
 
     auto sentinel_client
-        = cbdc::sentinel::rpc::client({cfg.m_sentinel_endpoints[our_sentinel]},
-                                      logger);
+        = cbdc::sentinel::rpc::client(cfg.m_sentinel_endpoints, logger);
     if(!sentinel_client.init()) {
         logger->error("Failed to connect to sentinel");
         return -1;


### PR DESCRIPTION
Pulled out from #87. Implements load balancing across multiple sentinels from load generators. Previously load generators were paired one-to-one with a sentinel. This PR makes load generators send transactions to all sentinels randomly selecting between them. This improves performance when a single sentinel is unable to absorb the load from a load generator.