### PR TITLE
Always start tx notify thread in atomizer

### DIFF
--- a/src/uhs/atomizer/atomizer/controller.cpp
+++ b/src/uhs/atomizer/atomizer/controller.cpp
@@ -83,11 +83,9 @@ namespace cbdc::atomizer {
             return false;
         }
 
-        if(m_opts.m_batch_size > 1) {
-            m_tx_notify_thread = std::thread{[&] {
-                tx_notify_handler();
-            }};
-        }
+        m_tx_notify_thread = std::thread{[&] {
+            tx_notify_handler();
+        }};
 
         m_main_thread = std::thread{[&] {
             main_handler();


### PR DESCRIPTION
Previously the transaction notification thread in the atomizer was only started when `m_opts.m_batch_size > 1`. Since this thread is always needed (notifications are always batched in the current code), remove that condition.