### PR TITLE
Wait to process incoming requests until syncronized with the atomizer

### DIFF
--- a/src/uhs/atomizer/shard/controller.cpp
+++ b/src/uhs/atomizer/shard/controller.cpp
@@ -136,7 +136,14 @@ namespace cbdc::shard {
         // If the block is not contiguous, catch up by requesting
         // blocks from the archiver.
         while(!m_shard.digest_block(blk)) {
-            m_logger->warn("Block", blk.m_height, "not contiguous.");
+            m_logger->warn("Block",
+                           blk.m_height,
+                           "not contiguous with previous block",
+                           m_shard.best_block_height());
+
+            if(blk.m_height <= m_shard.best_block_height()) {
+                break;
+            }
 
             // Attempt to catch up to the latest block
             for(uint64_t i = m_shard.best_block_height() + 1; i < blk.m_height;


### PR DESCRIPTION
This PR prevents the atomizer shard from listening on its server endpoint until it has received at least one block from the atomizer. This ensures that the shard will not be considered "up" until it has successfully connected to an atomizer. Without being synchronized with the atomizer, the shard cannot process any requests, so this is desirable behavior.