### PR TITLE
Update doxygen github action for gh-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Run Doxygen
-        uses: mattnotmitt/doxygen-action@1.9.3
+        uses: mattnotmitt/doxygen-action@edge
         with:
           working-directory: .
           doxyfile-path: ./Doxyfile


### PR DESCRIPTION
- Updates the doxygen github action to use the new edge version
- Fix allows pushes to gh-pages