### PR TITLE
Fix compilation on MacOS-arm64 using Apple Clang

### DIFF
--- a/tests/integration/atomizer_end_to_end_test.cpp
+++ b/tests/integration/atomizer_end_to_end_test.cpp
@@ -137,30 +137,30 @@ TEST_F(atomizer_end_to_end_test, complete_transaction) {
     ASSERT_TRUE(res.has_value());
     ASSERT_FALSE(res->m_tx_error.has_value());
     ASSERT_EQ(res->m_tx_status, cbdc::sentinel::tx_status::pending);
-    ASSERT_EQ(tx->m_outputs[0].m_value, 33);
-    ASSERT_EQ(m_sender->balance(), 60);
+    ASSERT_EQ(tx->m_outputs[0].m_value, 33UL);
+    ASSERT_EQ(m_sender->balance(), 60UL);
     auto in = m_sender->export_send_inputs(tx.value(), addr);
-    ASSERT_EQ(in.size(), 1);
+    ASSERT_EQ(in.size(), 1UL);
 
     std::this_thread::sleep_for(m_block_wait_interval);
     reload_sender();
-    ASSERT_EQ(m_sender->balance(), 60);
-    ASSERT_EQ(m_sender->pending_tx_count(), 1);
-    ASSERT_EQ(m_sender->pending_input_count(), 0);
+    ASSERT_EQ(m_sender->balance(), 60UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 1UL);
+    ASSERT_EQ(m_sender->pending_input_count(), 0UL);
     m_sender->sync();
-    ASSERT_EQ(m_sender->balance(), 67);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
+    ASSERT_EQ(m_sender->balance(), 67UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
 
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
     m_receiver->import_send_input(in[0]);
     reload_receiver();
-    ASSERT_EQ(m_receiver->balance(), 0);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 1);
+    ASSERT_EQ(m_receiver->balance(), 0UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 1UL);
     m_receiver->sync();
-    ASSERT_EQ(m_receiver->balance(), 33);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->balance(), 33UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
 }
 
 TEST_F(atomizer_end_to_end_test, double_spend) {
@@ -175,17 +175,17 @@ TEST_F(atomizer_end_to_end_test, double_spend) {
     ASSERT_TRUE(res.has_value());
     ASSERT_FALSE(res->m_tx_error.has_value());
     ASSERT_EQ(res->m_tx_status, cbdc::sentinel::tx_status::pending);
-    ASSERT_EQ(tx->m_outputs[0].m_value, 33);
-    ASSERT_EQ(m_sender->balance(), 60);
+    ASSERT_EQ(tx->m_outputs[0].m_value, 33UL);
+    ASSERT_EQ(m_sender->balance(), 60UL);
 
     std::this_thread::sleep_for(m_block_wait_interval);
     reload_sender();
-    ASSERT_EQ(m_sender->balance(), 60);
-    ASSERT_EQ(m_sender->pending_tx_count(), 1);
-    ASSERT_EQ(m_sender->pending_input_count(), 0);
+    ASSERT_EQ(m_sender->balance(), 60UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 1UL);
+    ASSERT_EQ(m_sender->pending_input_count(), 0UL);
     m_sender->sync();
-    ASSERT_EQ(m_sender->balance(), 67);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
+    ASSERT_EQ(m_sender->balance(), 67UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
 
     auto sc
         = cbdc::sentinel::rpc::client(m_opts.m_sentinel_endpoints, m_logger);

--- a/tests/integration/two_phase_end_to_end_test.cpp
+++ b/tests/integration/two_phase_end_to_end_test.cpp
@@ -53,7 +53,7 @@ class two_phase_end_to_end_test : public ::testing::Test {
         std::this_thread::sleep_for(m_wait_interval);
         m_sender->sync();
 
-        ASSERT_EQ(m_sender->balance(), 100);
+        ASSERT_EQ(m_sender->balance(), 100UL);
 
         reload_sender();
     }
@@ -125,21 +125,21 @@ TEST_F(two_phase_end_to_end_test, complete_transaction) {
     ASSERT_TRUE(res.has_value());
     ASSERT_FALSE(res->m_tx_error.has_value());
     ASSERT_EQ(res->m_tx_status, cbdc::sentinel::tx_status::confirmed);
-    ASSERT_EQ(tx->m_outputs[0].m_value, 33);
-    ASSERT_EQ(m_sender->balance(), 67);
+    ASSERT_EQ(tx->m_outputs[0].m_value, 33UL);
+    ASSERT_EQ(m_sender->balance(), 67UL);
     auto in = m_sender->export_send_inputs(tx.value(), addr);
-    ASSERT_EQ(in.size(), 1);
+    ASSERT_EQ(in.size(), 1UL);
 
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
     m_receiver->import_send_input(in[0]);
     reload_receiver();
-    ASSERT_EQ(m_receiver->balance(), 0);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 1);
+    ASSERT_EQ(m_receiver->balance(), 0UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 1UL);
     m_receiver->sync();
-    ASSERT_EQ(m_receiver->balance(), 33);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->balance(), 33UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
 }
 
 TEST_F(two_phase_end_to_end_test, duplicate_transaction) {
@@ -157,26 +157,26 @@ TEST_F(two_phase_end_to_end_test, duplicate_transaction) {
     ASSERT_FALSE(res2->m_tx_error.has_value());
     ASSERT_EQ(res->m_tx_status, cbdc::sentinel::tx_status::confirmed);
     ASSERT_EQ(res2->m_tx_status, cbdc::sentinel::tx_status::state_invalid);
-    ASSERT_EQ(tx->m_outputs[0].m_value, 33);
-    ASSERT_EQ(m_sender->balance(), 67);
+    ASSERT_EQ(tx->m_outputs[0].m_value, 33UL);
+    ASSERT_EQ(m_sender->balance(), 67UL);
     auto in = m_sender->export_send_inputs(tx.value(), addr);
-    ASSERT_EQ(in.size(), 1);
+    ASSERT_EQ(in.size(), 1UL);
 
     // Abandon the failed transaction
     auto abandoned
         = m_sender->abandon_transaction(cbdc::transaction::tx_id(tx.value()));
     ASSERT_TRUE(abandoned);
 
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
     m_receiver->import_send_input(in[0]);
     reload_receiver();
-    ASSERT_EQ(m_receiver->balance(), 0);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 1);
+    ASSERT_EQ(m_receiver->balance(), 0UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 1UL);
     m_receiver->sync();
-    ASSERT_EQ(m_receiver->balance(), 33);
-    ASSERT_EQ(m_sender->pending_tx_count(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->balance(), 33UL);
+    ASSERT_EQ(m_sender->pending_tx_count(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
 }
 
 TEST_F(two_phase_end_to_end_test, double_spend_transaction) {
@@ -189,18 +189,18 @@ TEST_F(two_phase_end_to_end_test, double_spend_transaction) {
     ASSERT_TRUE(res.has_value());
     ASSERT_FALSE(res->m_tx_error.has_value());
     ASSERT_EQ(res->m_tx_status, cbdc::sentinel::tx_status::confirmed);
-    ASSERT_EQ(tx->m_outputs[0].m_value, 33);
-    ASSERT_EQ(m_sender->balance(), 67);
+    ASSERT_EQ(tx->m_outputs[0].m_value, 33UL);
+    ASSERT_EQ(m_sender->balance(), 67UL);
     auto in = m_sender->export_send_inputs(tx.value(), addr);
-    ASSERT_EQ(in.size(), 1);
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(in.size(), 1UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
     m_receiver->import_send_input(in[0]);
     reload_receiver();
-    ASSERT_EQ(m_receiver->balance(), 0);
-    ASSERT_EQ(m_receiver->pending_input_count(), 1);
+    ASSERT_EQ(m_receiver->balance(), 0UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 1UL);
     m_receiver->sync();
-    ASSERT_EQ(m_receiver->balance(), 33);
-    ASSERT_EQ(m_receiver->pending_input_count(), 0);
+    ASSERT_EQ(m_receiver->balance(), 33UL);
+    ASSERT_EQ(m_receiver->pending_input_count(), 0UL);
 
     // Create a second transaction
     auto tx2 = m_sender->create_transaction(33, addr);
@@ -241,7 +241,7 @@ TEST_F(two_phase_end_to_end_test, double_spend_transaction) {
     ASSERT_TRUE(abandoned);
 
     // Confirm to see if our balance is restored after abandoning
-    ASSERT_EQ(m_sender->balance(), 67);
+    ASSERT_EQ(m_sender->balance(), 67UL);
 }
 
 TEST_F(two_phase_end_to_end_test, invalid_transaction) {

--- a/tests/integration/watchtower_integration_test.cpp
+++ b/tests/integration/watchtower_integration_test.cpp
@@ -62,7 +62,7 @@ class watchtower_integration_test : public ::testing::Test {
 
     static constexpr auto m_watchtower_cfg_path = "integration_tests.cfg";
 
-    static constexpr auto m_best_height{1};
+    static constexpr size_t m_best_height{1};
 
     cbdc::config::options m_opts{};
 

--- a/tests/unit/archiver_test.cpp
+++ b/tests/unit/archiver_test.cpp
@@ -96,7 +96,7 @@ TEST_F(ArchiverTest, archiver_leveldb_init_failure) {
 TEST_F(ArchiverTest, archiver_best_block_init) {
     ASSERT_TRUE(m_archiver->init_leveldb());
     ASSERT_TRUE(m_archiver->init_best_block());
-    ASSERT_EQ(m_archiver->best_block_height(), 0);
+    ASSERT_EQ(m_archiver->best_block_height(), 0UL);
 }
 
 // Test if the best block height is properly initialized to non-zero
@@ -110,7 +110,7 @@ TEST_F(ArchiverTest, archiver_best_block_init_nonzero) {
 
         archiver0->init_leveldb();
         archiver0->digest_block(m_dummy_blocks[0]);
-        ASSERT_EQ(archiver0->best_block_height(), 1);
+        ASSERT_EQ(archiver0->best_block_height(), 1UL);
     }
     {
         auto archiver1
@@ -121,7 +121,7 @@ TEST_F(ArchiverTest, archiver_best_block_init_nonzero) {
 
         archiver1->init_leveldb();
         archiver1->init_best_block();
-        ASSERT_EQ(archiver1->best_block_height(), 1);
+        ASSERT_EQ(archiver1->best_block_height(), 1UL);
     }
 }
 
@@ -195,7 +195,7 @@ TEST_F(ArchiverTest, digest_block) {
     m_archiver->init_leveldb();
     m_archiver->init_best_block();
     m_archiver->digest_block(m_dummy_blocks[0]);
-    ASSERT_EQ(m_archiver->best_block_height(), 1);
+    ASSERT_EQ(m_archiver->best_block_height(), 1UL);
 }
 
 // Test if the archiver properly defers digestion of a block that is received
@@ -204,11 +204,11 @@ TEST_F(ArchiverTest, digest_block_deferral) {
     m_archiver->init_leveldb();
     m_archiver->init_best_block();
     m_archiver->digest_block(m_dummy_blocks[0]);
-    ASSERT_EQ(m_archiver->best_block_height(), 1);
+    ASSERT_EQ(m_archiver->best_block_height(), 1UL);
     m_archiver->digest_block(m_dummy_blocks[2]);
-    ASSERT_EQ(m_archiver->best_block_height(), 1);
+    ASSERT_EQ(m_archiver->best_block_height(), 1UL);
     m_archiver->digest_block(m_dummy_blocks[1]);
-    ASSERT_EQ(m_archiver->best_block_height(), 3);
+    ASSERT_EQ(m_archiver->best_block_height(), 3UL);
 }
 
 // Test the get_block function
@@ -220,8 +220,8 @@ TEST_F(ArchiverTest, get_block) {
     m_archiver->digest_block(m_dummy_blocks[2]);
     auto blk = m_archiver->get_block(1);
     ASSERT_TRUE(blk.has_value());
-    ASSERT_EQ(blk.value().m_height, 1);
-    ASSERT_EQ(blk.value().m_transactions.size(), 20);
+    ASSERT_EQ(blk.value().m_height, 1UL);
+    ASSERT_EQ(blk.value().m_transactions.size(), 20UL);
     ASSERT_EQ(blk.value().m_transactions[2].m_id,
               m_dummy_blocks[0].m_transactions[2].m_id);
 }
@@ -244,8 +244,8 @@ TEST_F(ArchiverTest, server_handler) {
     std::optional<cbdc::atomizer::block> blk;
     deser >> blk;
     ASSERT_TRUE(blk.has_value());
-    ASSERT_EQ(blk.value().m_height, 1);
-    ASSERT_EQ(blk.value().m_transactions.size(), 20);
+    ASSERT_EQ(blk.value().m_height, 1UL);
+    ASSERT_EQ(blk.value().m_transactions.size(), 20UL);
     ASSERT_EQ(blk.value().m_transactions[2].m_id,
               m_dummy_blocks[0].m_transactions[2].m_id);
 }
@@ -264,8 +264,8 @@ TEST_F(ArchiverTest, client) {
     ASSERT_TRUE(client.init());
     auto blk = client.get_block(1);
     ASSERT_TRUE(blk.has_value());
-    ASSERT_EQ(blk.value().m_height, 1);
-    ASSERT_EQ(blk.value().m_transactions.size(), 20);
+    ASSERT_EQ(blk.value().m_height, 1UL);
+    ASSERT_EQ(blk.value().m_transactions.size(), 20UL);
     ASSERT_EQ(blk.value().m_transactions[2].m_id,
               m_dummy_blocks[0].m_transactions[2].m_id);
 }
@@ -290,5 +290,5 @@ TEST_F(ArchiverTest, init) {
     m_archiver->digest_block(m_dummy_blocks[0]);
     auto blk = m_archiver->get_block(1);
     ASSERT_TRUE(blk.has_value());
-    ASSERT_EQ(m_archiver->best_block_height(), 1);
+    ASSERT_EQ(m_archiver->best_block_height(), 1UL);
 }

--- a/tests/unit/atomizer_test.cpp
+++ b/tests/unit/atomizer_test.cpp
@@ -142,7 +142,7 @@ TEST_F(atomizer_test, err_incomplete) {
     ASSERT_FALSE(err.has_value());
 
     errs = m_atomizer->make_block().second;
-    ASSERT_EQ(errs.size(), 1);
+    ASSERT_EQ(errs.size(), 1UL);
     auto want
         = cbdc::watchtower::tx_error{{'A'},
                                      cbdc::watchtower::tx_error_incomplete{}};

--- a/tests/unit/config_test.cpp
+++ b/tests/unit/config_test.cpp
@@ -97,7 +97,7 @@ TEST_F(config_validation_test, parsing_validation) {
 
     auto window_size = ex.get_ulong("window_size");
     EXPECT_TRUE(window_size.has_value());
-    EXPECT_EQ(window_size.value(), 40000);
+    EXPECT_EQ(window_size.value(), 40000UL);
 
     auto endpoint = ex.get_endpoint("archiver0_endpoint");
     EXPECT_TRUE(endpoint.has_value());

--- a/tests/unit/network_test.cpp
+++ b/tests/unit/network_test.cpp
@@ -94,7 +94,7 @@ TEST_F(NetworkTest, reset_net) {
 
     m_blocking_net->close();
     listener.join();
-    ASSERT_EQ(m_blocking_net->peer_count(), 0);
+    ASSERT_EQ(m_blocking_net->peer_count(), 0UL);
 
     m_blocking_net->reset();
     ASSERT_TRUE(m_blocking_net->listen(cbdc::network::localhost, listen_port));

--- a/tests/unit/serialization/format_test.cpp
+++ b/tests/unit/serialization/format_test.cpp
@@ -41,7 +41,7 @@ TEST_F(format_test, inordinate_declared_lengths_are_handled) {
     deser >> r0;
 
     EXPECT_FALSE(deser);
-    EXPECT_EQ(r0.size(), 4);
+    EXPECT_EQ(r0.size(), 4UL);
     EXPECT_EQ(r0.capacity(), 1024UL * 1024UL / sizeof(uint64_t));
 }
 

--- a/tests/unit/serialization_test.cpp
+++ b/tests/unit/serialization_test.cpp
@@ -73,10 +73,10 @@ TEST_F(SerializationTest, TestDummy) {
     ASSERT_FALSE(sz.end_of_buffer());
 
     sz.reset();
-    ASSERT_EQ(sz.size(), 0);
+    ASSERT_EQ(sz.size(), 0UL);
 
     sz.advance_cursor(10);
-    ASSERT_EQ(sz.size(), 10);
+    ASSERT_EQ(sz.size(), 10UL);
 }
 
 TEST_F(SerializationTest, TestEndOfBuffer) {

--- a/tests/unit/wallet_test.cpp
+++ b/tests/unit/wallet_test.cpp
@@ -58,7 +58,7 @@ TEST_F(WalletTest, export_send_input_basic) {
     auto send_tx = m_wallet.send_to(25, target_addr, false).value();
     auto receiver_inputs
         = cbdc::transaction::wallet::export_send_inputs(send_tx, target_addr);
-    ASSERT_EQ(receiver_inputs.size(), 1);
+    ASSERT_EQ(receiver_inputs.size(), 1UL);
 
     ASSERT_EQ(receiver_inputs[0].m_prevout.m_tx_id,
               cbdc::transaction::tx_id(send_tx));
@@ -68,33 +68,33 @@ TEST_F(WalletTest, export_send_input_basic) {
 TEST_F(WalletTest, fan_out) {
     cbdc::pubkey_t target_addr = {'a', 'b', 'c', 'd'};
     auto send_tx = m_wallet.fan(20, 5, target_addr, false).value();
-    ASSERT_EQ(send_tx.m_outputs.size(), 20);
+    ASSERT_EQ(send_tx.m_outputs.size(), 20UL);
     auto witcom = cbdc::transaction::validation::get_p2pk_witness_commitment(
         target_addr);
     for(const auto& out : send_tx.m_outputs) {
-        ASSERT_EQ(out.m_value, 5);
+        ASSERT_EQ(out.m_value, 5UL);
         ASSERT_EQ(out.m_witness_program_commitment, witcom);
     }
     auto receiver_inputs
         = cbdc::transaction::wallet::export_send_inputs(send_tx, target_addr);
-    ASSERT_EQ(receiver_inputs.size(), 20);
+    ASSERT_EQ(receiver_inputs.size(), 20UL);
 }
 
 TEST_F(WalletTest, fan_out_change) {
     cbdc::pubkey_t target_addr = {'a', 'b', 'c', 'd'};
     auto send_tx = m_wallet.fan(19, 5, target_addr, false).value();
-    ASSERT_EQ(send_tx.m_outputs.size(), 20);
+    ASSERT_EQ(send_tx.m_outputs.size(), 20UL);
     auto witcom = cbdc::transaction::validation::get_p2pk_witness_commitment(
         target_addr);
     for(size_t i = 1; i < send_tx.m_outputs.size(); i++) {
-        ASSERT_EQ(send_tx.m_outputs[i].m_value, 5);
+        ASSERT_EQ(send_tx.m_outputs[i].m_value, 5UL);
         ASSERT_EQ(send_tx.m_outputs[i].m_witness_program_commitment, witcom);
     }
-    ASSERT_EQ(send_tx.m_outputs[0].m_value, 5);
+    ASSERT_EQ(send_tx.m_outputs[0].m_value, 5UL);
     ASSERT_NE(send_tx.m_outputs[0].m_witness_program_commitment, witcom);
     auto receiver_inputs
         = cbdc::transaction::wallet::export_send_inputs(send_tx, target_addr);
-    ASSERT_EQ(receiver_inputs.size(), 19);
+    ASSERT_EQ(receiver_inputs.size(), 19UL);
 }
 
 class WalletTxTest : public ::testing::Test {

--- a/tests/unit/watchtower/block_cache_test.cpp
+++ b/tests/unit/watchtower/block_cache_test.cpp
@@ -29,12 +29,12 @@ TEST_F(BlockCacheTest, no_history) {
     ASSERT_FALSE(m_bc.check_spent({'Z'}).has_value());
     ASSERT_FALSE(m_bc.check_unspent({'Z'}).has_value());
 
-    ASSERT_EQ(m_bc.best_block_height(), 44);
+    ASSERT_EQ(m_bc.best_block_height(), 44UL);
 }
 
 TEST_F(BlockCacheTest, spend_g) {
     ASSERT_FALSE(m_bc.check_spent({'G'}).has_value());
-    ASSERT_EQ(m_bc.check_unspent({'G'}).value().first, 44);
+    ASSERT_EQ(m_bc.check_unspent({'G'}).value().first, 44UL);
     ASSERT_EQ(m_bc.check_unspent({'G'}).value().second, cbdc::hash_t{'E'});
 
     cbdc::atomizer::block b1;
@@ -44,13 +44,13 @@ TEST_F(BlockCacheTest, spend_g) {
     m_bc.push_block(std::move(b1));
 
     ASSERT_FALSE(m_bc.check_unspent({'G'}).has_value());
-    ASSERT_EQ(m_bc.check_spent({'G'}).value().first, 45);
+    ASSERT_EQ(m_bc.check_spent({'G'}).value().first, 45UL);
     ASSERT_EQ(m_bc.check_spent({'G'}).value().second, cbdc::hash_t{'L'});
 }
 
 TEST_F(BlockCacheTest, add_k_plus_1) {
     ASSERT_FALSE(m_bc.check_spent({'G'}).has_value());
-    ASSERT_EQ(m_bc.check_unspent({'G'}).value().first, 44);
+    ASSERT_EQ(m_bc.check_unspent({'G'}).value().first, 44UL);
     ASSERT_EQ(m_bc.check_unspent({'G'}).value().second, cbdc::hash_t{'E'});
 
     cbdc::atomizer::block b1;
@@ -77,8 +77,8 @@ TEST_F(BlockCacheTest, add_k_plus_1) {
     m_bc.push_block(std::move(b3));
 
     ASSERT_FALSE(m_bc.check_unspent({'G'}).has_value());
-    ASSERT_EQ(m_bc.check_spent({'G'}).value().first, 47);
+    ASSERT_EQ(m_bc.check_spent({'G'}).value().first, 47UL);
     ASSERT_EQ(m_bc.check_spent({'G'}).value().second, cbdc::hash_t{'X'});
 
-    ASSERT_EQ(m_bc.best_block_height(), 47);
+    ASSERT_EQ(m_bc.best_block_height(), 47UL);
 }


### PR DESCRIPTION
This PR adds type postfixes to the literals in the tests. This is required by Apple Clang which complains about mismatched types.

```
[build] /usr/bin/clang++ -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -D_NO_EXCEPTION -I/Users/james/workspace/cbdc-universe0/3rdparty -I/Users/james/workspace/cbdc-universe0/3rdparty/secp256k1/include -I/usr/local/include -I/opt/homebrew/include -I/Users/james/workspace/cbdc-universe0/tests/. -I/Users/james/workspace/cbdc-universe0/tests/../src -I/Users/james/workspace/cbdc-universe0/tests/../tools/watchtower -I/Users/james/workspace/cbdc-universe0/tests/../3rdparty -I/Users/james/workspace/cbdc-universe0/tests/../3rdparty/secp256k1/include -isystem /opt/homebrew/anaconda3/include -isystem /usr/local/include -fno-rtti -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fprofile-arcs -ftest-coverage -Wall -Wextra -pedantic -Werror -fno-exceptions -Wshadow-all -Wnewline-eof -std=c++17 -MD -MT tests/unit/CMakeFiles/run_unit_tests.dir/serialization_test.o -MF tests/unit/CMakeFiles/run_unit_tests.dir/serialization_test.o.d -o tests/unit/CMakeFiles/run_unit_tests.dir/serialization_test.o -c /Users/james/workspace/cbdc-universe0/tests/unit/serialization_test.cpp
[build] In file included from /Users/james/workspace/cbdc-universe0/tests/unit/serialization_test.cpp:11:
[build] /opt/homebrew/include/gtest/gtest.h:1545:11: error: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Werror,-Wsign-compare]
[build]   if (lhs == rhs) {
[build]       ~~~ ^  ~~~
[build] /opt/homebrew/include/gtest/gtest.h:1564:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned long, int>' requested here
[build]     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
[build]            ^
[build] /Users/james/workspace/cbdc-universe0/tests/unit/serialization_test.cpp:76:5: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<unsigned long, int, nullptr>' requested here
[build]     ASSERT_EQ(sz.size(), 0);
[build]     ^
[build] /opt/homebrew/include/gtest/gtest.h:2073:32: note: expanded from macro 'ASSERT_EQ'
[build] # define ASSERT_EQ(val1, val2) GTEST_ASSERT_EQ(val1, val2)
[build]                                ^
[build] /opt/homebrew/include/gtest/gtest.h:2057:54: note: expanded from macro 'GTEST_ASSERT_EQ'
[build]   ASSERT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
[build]                                                      ^
[build] 1 error generated.
```