### PR TITLE
Merge macOS build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,28 +56,21 @@ For more information on how to contribute, please see our [Contribution Guide](d
 Use these directions if you want to build the source on your machine.
 If you just want to run the system, see "Run the Code" below.
 
+1. Install the necessary libraries and resources
+  ```terminal
+  # ./scripts/configure.sh
+  ```
+2. Run the build
+  ```terminal
+  # ./scripts/build.sh
+  ```
+
 ## macOS
-Ensure your development environment is set correctly for clang:
+Note that if you have not already installed the xcode cli tools you will need to:
 
-`sudo xcode-select -switch /Library/Developer/CommandLineTools`
-
-Or, if you've changed this in the past, you can reset to point to commandline tools with:
-
-`sudo xcode-select --reset`
-
-
-1. Install dependencies: `brew install leveldb llvm@11 googletest lcov make wget cmake`
-2. `./scripts/configure.sh`
-3. `./scripts/build.sh`
-
-Note: To run clang-tidy and clang-format (required by `lint.sh`), you must add them both to your path.
-
-Ex: `ln -s /usr/local/opt/llvm@11/bin/clang-tidy /usr/local/bin/clang-tidy`
-
-## Linux
-
-1. `./scripts/configure.sh`
-2. `./scripts/build.sh`
+```terminal
+# xcode-select --install
+```
 
 # Run the Code
 

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -24,6 +24,17 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   CPUS=$(grep -c ^processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
+  # ensure development environment is set correctly for clang
+  $SUDO xcode-select -switch /Library/Developer/CommandLineTools
+  brew install leveldb llvm@11 googletest lcov make wget cmake
+  CLANG_TIDY=/usr/local/bin/clang-tidy
+  if [ ! -L "$CLANG_TIDY" ]; then
+    $SUDO ln -s $(brew --prefix)/opt/llvm@11/bin/clang-tidy /usr/local/bin/clang-tidy
+  fi
+  GMAKE=/usr/local/bin/gmake
+  if [ ! -L "$GMAKE" ]; then
+    $SUDO ln -s $(xcode-select -p)/usr/bin/gnumake /usr/local/bin/gmake
+  fi
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
Hi,

I tried to make some additional improvements to the build/run steps for mac.
1. The additional build steps for mac have been moved from `README.md` into `./scripts/configure.sh`. This means that the instructions for linux and macOS are now the same. I left the note on installing xcode tools in the instructions because I believe it triggers a prompt to accept an agreement. 
2. The install location for `brew` is different on intel and arm macs (https://docs.brew.sh/Installation), this updates the `clang-tidy` linking command to use the correct location.
3. I noticed that the `build.sh` script could also fail due to missing `gmake`, so it is now linked if needed.

Let me know what you think. I'm happy to make any requested changes.

Thanks

Signed-off-by: Jon Wiggins <me@jonwiggins.org>