### PR TITLE
Extend test script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,12 +10,19 @@ DESCRIPTION:
     This script runs unit and integration tests and measures test coverage. 
 
 FLAGS: 
+    -nu, --no-unit-tests            Do not run unit tests.
+                                    Default:  false
+    -ni, --no-integration-tests     Do not run integration tests.
+                                    Default:  false
     -nc, --no-coverage              Do not measure test coverage.
                                     Default:  false
     -h, --help                      Show usage.
 	"
 }
 
+# Parse command-line arguments.
+RUN_UNIT_TESTS="true"
+RUN_INTEGRATION_TESTS="true"
 MEASURE_COVERAGE="true"
 while [[ $# -gt 0 ]]
 do
@@ -24,6 +31,14 @@ do
             usage
             exit 0
             ;; 
+        -ni|--no-integration-tests)
+            RUN_INTEGRATION_TESTS="false"
+            shift 
+            ;;
+        -nu|--no-unit-tests)
+            RUN_UNIT_TESTS="false"
+            shift 
+            ;;
         -nc|--no-coverage)
             MEASURE_COVERAGE="false"
             shift
@@ -77,10 +92,21 @@ run_test_suite () {
     cd ..
 }
 
-echo "Running unit tests..."
-run_test_suite "tests/unit/run_unit_tests" "unit_tests_coverage"
+if [[ $RUN_UNIT_TESTS == "true" ]]
+then 
+    echo "Running unit tests..."
+    run_test_suite "tests/unit/run_unit_tests" "unit_tests_coverage"
+else
+    echo "Skipping unit tests."
+fi
 
-echo "Running integration tests..."
-cp tests/integration/*.cfg "$BUILD_DIR"
-run_test_suite "tests/integration/run_integration_tests" \
-    "integration_tests_coverage"
+echo
+if [[ $RUN_INTEGRATION_TESTS == "true" ]]
+then
+    echo "Running integration tests..."
+    cp tests/integration/*.cfg "$BUILD_DIR"
+    run_test_suite "tests/integration/run_integration_tests" \
+        "integration_tests_coverage"
+else
+    echo "Skipping integration tests."
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,6 +19,19 @@ FLAGS:
     -nc, --no-coverage              Do not measure test coverage.
                                     Default:  false
     -h, --help                      Show usage.
+
+EXAMPLES:
+    - Run unit tests and integration tests and measure test coverage.  Assume
+      the build directory is 'opencbdc-tx/build'.
+    $ ./test.sh 
+
+    - Run integration tests but do not run unit tests.  Do not measure
+      test coverage.  Assume the build directory is 'opencbdc-tx/build'.
+    $ ./test.sh -nu -nc
+
+    - Run unit tests and integration tests and measure test coverage.  Set the 
+      build directory to 'mybuild'.
+    $ ./test.sh -d mybuild
 	"
 }
 
@@ -112,7 +125,7 @@ run_test_suite () {
     if [[ "$MEASURE_COVERAGE" == "true" ]]
     then
         echo "Checking test coverage."
-        LOCATION=$2
+        LOCATION="$2"
         rm -rf "$LOCATION"
         mkdir -p "$LOCATION"
         find . \( -name '*.gcno' -or -name '*.gcda' \) \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,14 +14,17 @@ run_test_suite () {
     LOCATION=$2
     rm -rf "$LOCATION"
     mkdir -p "$LOCATION"
-    find . \( -name '*.gcno' -or -name '*.gcda' \) -and -not -path '*coverage*' -exec cp --parents \{\} "$LOCATION" \;
+    find . \( -name '*.gcno' -or -name '*.gcda' \) \
+        -and -not -path '*coverage*' -exec cp --parents \{\} "$LOCATION" \;
     cd "$LOCATION"
 
     lcov -c -i -d . -o base.info --rc lcov_branch_coverage=1
     lcov -c -d . -o test.info --rc lcov_branch_coverage=1
     lcov -a base.info -a test.info -o total.info --rc lcov_branch_coverage=1
-    lcov --remove total.info '*/3rdparty/*' '*/tests/*' '*/tools/*' -o trimmed.info --rc lcov_branch_coverage=1
-    lcov --extract trimmed.info '*/src/*' -o cov.info --rc lcov_branch_coverage=1
+    lcov --remove total.info '*/3rdparty/*' '*/tests/*' '*/tools/*' \
+        -o trimmed.info --rc lcov_branch_coverage=1
+    lcov --extract trimmed.info '*/src/*' -o cov.info \
+        --rc lcov_branch_coverage=1
     genhtml cov.info -o output --rc genhtml_branch_coverage=1
 
     cd ../..
@@ -32,4 +35,5 @@ run_test_suite "tests/unit/run_unit_tests" "unit_tests_coverage"
 
 echo "Running integration tests..."
 cp tests/integration/*.cfg "$BUILD_DIR"
-run_test_suite "tests/integration/run_integration_tests" "integration_tests_coverage"
+run_test_suite "tests/integration/run_integration_tests" \
+    "integration_tests_coverage"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,45 @@
 # Exit script on failure.
 set -e
 
+function usage() { echo "
+USAGE:
+    ./test.sh
+
+DESCRIPTION:
+    This script runs unit and integration tests and measures test coverage. 
+
+FLAGS: 
+    -nc, --no-coverage              Do not measure test coverage.
+                                    Default:  false
+    -h, --help                      Show usage.
+	"
+}
+
+MEASURE_COVERAGE="true"
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;; 
+        -nc|--no-coverage)
+            MEASURE_COVERAGE="false"
+            shift
+            ;; 
+        -*)
+            echo "ERROR:  unknown command-line option '${1}'."
+            usage
+            exit 1
+            ;;
+        *)
+            echo "ERROR:  unknown command-line option '${1}'."
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 if [ -z ${BUILD_DIR+x} ]; then
     export BUILD_DIR=build
 fi
@@ -11,23 +50,31 @@ run_test_suite () {
     find . -name '*.gcda' -exec rm {} \;
     "$PWD"/"$1"
 
-    LOCATION=$2
-    rm -rf "$LOCATION"
-    mkdir -p "$LOCATION"
-    find . \( -name '*.gcno' -or -name '*.gcda' \) \
-        -and -not -path '*coverage*' -exec cp --parents \{\} "$LOCATION" \;
-    cd "$LOCATION"
+    if [[ "$MEASURE_COVERAGE" == "true" ]]
+    then
+        echo "Checking test coverage."
+        LOCATION=$2
+        rm -rf "$LOCATION"
+        mkdir -p "$LOCATION"
+        find . \( -name '*.gcno' -or -name '*.gcda' \) \
+            -and -not -path '*coverage*' -exec cp --parents \{\} "$LOCATION" \;
+        cd "$LOCATION"
 
-    lcov -c -i -d . -o base.info --rc lcov_branch_coverage=1
-    lcov -c -d . -o test.info --rc lcov_branch_coverage=1
-    lcov -a base.info -a test.info -o total.info --rc lcov_branch_coverage=1
-    lcov --remove total.info '*/3rdparty/*' '*/tests/*' '*/tools/*' \
-        -o trimmed.info --rc lcov_branch_coverage=1
-    lcov --extract trimmed.info '*/src/*' -o cov.info \
-        --rc lcov_branch_coverage=1
-    genhtml cov.info -o output --rc genhtml_branch_coverage=1
+        lcov -c -i -d . -o base.info --rc lcov_branch_coverage=1
+        lcov -c -d . -o test.info --rc lcov_branch_coverage=1
+        lcov -a base.info -a test.info -o total.info --rc lcov_branch_coverage=1
+        lcov --remove total.info '*/3rdparty/*' '*/tests/*' '*/tools/*' \
+            -o trimmed.info --rc lcov_branch_coverage=1
+        lcov --extract trimmed.info '*/src/*' -o cov.info \
+            --rc lcov_branch_coverage=1
+        genhtml cov.info -o output --rc genhtml_branch_coverage=1
 
-    cd ../..
+        cd ..
+    else
+        echo "Skipping coverage measurement."
+    fi
+
+    cd ..
 }
 
 echo "Running unit tests..."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# exit script on failure
+# Exit script on failure.
 set -e
 
 if [ -z ${BUILD_DIR+x} ]; then
@@ -7,15 +7,15 @@ if [ -z ${BUILD_DIR+x} ]; then
 fi
 
 run_test_suite () {
-    cd $BUILD_DIR
+    cd "$BUILD_DIR"
     find . -name '*.gcda' -exec rm {} \;
-    $PWD/$1
+    "$PWD"/"$1"
 
     LOCATION=$2
-    rm -rf $LOCATION
-    mkdir -p $LOCATION
+    rm -rf "$LOCATION"
+    mkdir -p "$LOCATION"
     find . \( -name '*.gcno' -or -name '*.gcda' \) -and -not -path '*coverage*' -exec cp --parents \{\} "$LOCATION" \;
-    cd $LOCATION
+    cd "$LOCATION"
 
     lcov -c -i -d . -o base.info --rc lcov_branch_coverage=1
     lcov -c -d . -o test.info --rc lcov_branch_coverage=1
@@ -31,5 +31,5 @@ echo "Running unit tests..."
 run_test_suite "tests/unit/run_unit_tests" "unit_tests_coverage"
 
 echo "Running integration tests..."
-cp tests/integration/*.cfg $BUILD_DIR
+cp tests/integration/*.cfg "$BUILD_DIR"
 run_test_suite "tests/integration/run_integration_tests" "integration_tests_coverage"


### PR DESCRIPTION
This pull request addresses [Issue 122, 'Extend test.sh'](https://github.com/mit-dci/opencbdc-tx/issues/122).  `test.sh` is the script that runs unit tests and integration tests and measures coverage.  This pull request contains commits that extend it in the following ways:

- Users can now choose via command-line arguments which tests to run (e.g. unit tests, integration tests, or both) and whether to measure coverage.
- Users can now define the build folder via a command-line argument.
- Users can now run the script from any folder.
- Users can now read about what the script does and how to use it by calling it with `-h` or `--help` flags.

In addition, `test.sh` now adheres to the 80-char. line limit followed in the repo's C++ code.  It also now has variable references enclosed in double quotes, as recommended in the [Advanced Bash Scripting Guide](https://tldp.org/LDP/abs/html/quotingvar.html).

The new `test.sh` in this pull request is completely _backward compatible_:  running it with no command-line arguments does exactly what the previous version of the script does.  As a result, documentation that references the script and code that invokes it should not need to change.  Also, users don't need to change how they use the script if they don't want to.