### PR TITLE
Add NuRaft handler commit_config()

### DIFF
--- a/src/uhs/atomizer/atomizer/state_machine.cpp
+++ b/src/uhs/atomizer/atomizer/state_machine.cpp
@@ -41,6 +41,7 @@ namespace cbdc::atomizer {
 
     auto state_machine::commit(nuraft::ulong log_idx, nuraft::buffer& data)
         -> nuraft::ptr<nuraft::buffer> {
+        assert(log_idx == m_last_committed_idx + 1);
         m_last_committed_idx = log_idx;
         auto req = from_buffer<request>(data);
         assert(req.has_value());
@@ -102,6 +103,7 @@ namespace cbdc::atomizer {
     void state_machine::commit_config(
         const nuraft::ulong log_idx,
         nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) {
+        assert(log_idx == m_last_committed_idx + 1);
         m_last_committed_idx = log_idx;
     }
 

--- a/src/uhs/atomizer/atomizer/state_machine.cpp
+++ b/src/uhs/atomizer/atomizer/state_machine.cpp
@@ -99,6 +99,12 @@ namespace cbdc::atomizer {
             resp.value());
     }
 
+    void state_machine::commit_config(
+        const nuraft::ulong log_idx,
+        nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) {
+        m_last_committed_idx = log_idx;
+    }
+
     auto
     state_machine::read_logical_snp_obj(nuraft::snapshot& s,
                                         void*& /* user_snp_ctx */,

--- a/src/uhs/atomizer/atomizer/state_machine.hpp
+++ b/src/uhs/atomizer/atomizer/state_machine.hpp
@@ -45,6 +45,12 @@ namespace cbdc::atomizer {
         [[nodiscard]] auto commit(nuraft::ulong log_idx, nuraft::buffer& data)
             -> nuraft::ptr<nuraft::buffer> override;
 
+        /// Handler for the raft cluster configuration changes
+        /// \param log_idx Raft log number of the configuration change.
+        void commit_config(
+            nuraft::ulong log_idx,
+            nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) override;
+
         /// Read the portion of the state machine snapshot associated with
         /// the given metadata and object ID into a buffer.
         /// \param s metadata of snapshot to read.

--- a/src/uhs/twophase/coordinator/state_machine.cpp
+++ b/src/uhs/twophase/coordinator/state_machine.cpp
@@ -13,6 +13,7 @@
 namespace cbdc::coordinator {
     auto state_machine::commit(uint64_t log_idx, nuraft::buffer& data)
         -> nuraft::ptr<nuraft::buffer> {
+        assert(log_idx == m_last_committed_idx + 1);
         m_last_committed_idx = log_idx;
         auto comm = cbdc::coordinator::controller::sm_command_header();
         auto deser = cbdc::nuraft_serializer(data);
@@ -88,6 +89,13 @@ namespace cbdc::coordinator {
             }
         }
         return nullptr;
+    }
+
+    void state_machine::commit_config(
+        const nuraft::ulong log_idx,
+        nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) {
+        assert(log_idx == m_last_committed_idx + 1);
+        m_last_committed_idx = log_idx;
     }
 
     auto state_machine::apply_snapshot(nuraft::snapshot& /* s */) -> bool {

--- a/src/uhs/twophase/coordinator/state_machine.hpp
+++ b/src/uhs/twophase/coordinator/state_machine.hpp
@@ -65,6 +65,12 @@ namespace cbdc::coordinator {
         auto commit(uint64_t log_idx, nuraft::buffer& data)
             -> nuraft::ptr<nuraft::buffer> override;
 
+        /// Handler for the raft cluster configuration changes
+        /// \param log_idx Raft log number of the configuration change.
+        void commit_config(
+            nuraft::ulong log_idx,
+            nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) override;
+
         /// Not implemented for coordinators.
         /// \return false (unconditionally).
         auto apply_snapshot(nuraft::snapshot& /* s */) -> bool override;

--- a/src/uhs/twophase/locking_shard/state_machine.cpp
+++ b/src/uhs/twophase/locking_shard/state_machine.cpp
@@ -32,6 +32,7 @@ namespace cbdc::locking_shard {
 
     auto state_machine::commit(uint64_t log_idx, nuraft::buffer& data)
         -> nuraft::ptr<nuraft::buffer> {
+        assert(log_idx == m_last_committed_idx + 1);
         m_last_committed_idx = log_idx;
 
         auto resp = blocking_call(data);
@@ -43,6 +44,13 @@ namespace cbdc::locking_shard {
         }
 
         return resp.value();
+    }
+
+    void state_machine::commit_config(
+        const nuraft::ulong log_idx,
+        nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) {
+        assert(log_idx == m_last_committed_idx + 1);
+        m_last_committed_idx = log_idx;
     }
 
     auto state_machine::apply_snapshot(nuraft::snapshot& /* s */) -> bool {

--- a/src/uhs/twophase/locking_shard/state_machine.hpp
+++ b/src/uhs/twophase/locking_shard/state_machine.hpp
@@ -46,6 +46,12 @@ namespace cbdc::locking_shard {
         auto commit(uint64_t log_idx, nuraft::buffer& data)
             -> nuraft::ptr<nuraft::buffer> override;
 
+        /// Handler for the raft cluster configuration changes
+        /// \param log_idx Raft log number of the configuration change.
+        void commit_config(
+            nuraft::ulong log_idx,
+            nuraft::ptr<nuraft::cluster_config>& /*new_conf*/) override;
+
         /// Not implemented for locking shard.
         /// \return false.
         auto apply_snapshot(nuraft::snapshot& /* s */) -> bool override;


### PR DESCRIPTION
Add NuRaft handler commit_config() to maintain synchronization of last committed index with latest log index

Fix #125
Signed-off-by: Alexander Jung <104335080+AlexRamRam@users.noreply.github.com>