### PR TITLE
Fix bug in reconnect logic causing an infinite send loop

### DIFF
--- a/src/util/common/blocking_queue.hpp
+++ b/src/util/common/blocking_queue.hpp
@@ -83,6 +83,14 @@ namespace cbdc {
             m_cv.notify_all();
         }
 
+        /// Removes the wakeup flag for consumers. Must be called after
+        /// \ref clear() before re-using the queue. All consumers must have
+        /// returned from \ref pop() before calling this method.
+        void reset() {
+            std::unique_lock l(m_mut);
+            m_wake = false;
+        }
+
       private:
         std::queue<T> m_buffer;
         std::mutex m_mut;

--- a/src/util/network/peer.cpp
+++ b/src/util/network/peer.cpp
@@ -5,6 +5,7 @@
 
 #include "peer.hpp"
 
+#include <cassert>
 #include <utility>
 
 namespace cbdc::network {
@@ -47,7 +48,8 @@ namespace cbdc::network {
             while(m_running) {
                 std::shared_ptr<cbdc::buffer> pkt;
                 if(!m_send_queue.pop(pkt)) {
-                    continue;
+                    assert(!m_running);
+                    break;
                 }
 
                 if(pkt) {
@@ -123,6 +125,7 @@ namespace cbdc::network {
         if(m_recv_thread.joinable()) {
             m_recv_thread.join();
         }
+        m_send_queue.reset();
     }
 
     void peer::signal_reconnect() {


### PR DESCRIPTION
This PR fixes the reconnect logic for peers in the connection manager. Before this PR, a socket disconnect would trigger a reconnect, causing `do_send()` to drop into a tight loop, consuming all the CPU. This was because the `m_wake` flag was never reset, causing `pop()` to always return false after `clear()`. Since the loop calling `pop()` used `continue` rather than `break`, the loop never ended.

The PR provides a method to reset the wakeup flag, and properly breaks out of the send loop when `pop()` returns false.