### PR TITLE
Fix shard-seeder for atomizer

### DIFF
--- a/tools/shard-seeder/shard-seeder.cpp
+++ b/tools/shard-seeder/shard-seeder.cpp
@@ -50,7 +50,12 @@ auto main(int argc, char** argv) -> int {
 
     auto start = std::chrono::system_clock::now();
 
-    auto num_shards = cfg.m_shard_ranges.size();
+    auto unique_ranges
+        = std::vector<cbdc::config::shard_range_t>(cfg.m_shard_ranges);
+    std::sort(unique_ranges.begin(), unique_ranges.end());
+    unique_ranges.erase(unique(unique_ranges.begin(), unique_ranges.end()),
+                        unique_ranges.end());
+    auto num_shards = unique_ranges.size();
     auto num_utxos = cfg.m_seed_to - cfg.m_seed_from;
     auto utxo_val = cfg.m_seed_value;
     if(!cfg.m_seed_privkey.has_value()) {


### PR DESCRIPTION
When using an atomizer configuration with a shard replication factor of >1, the shard seeder will not function properly.

The reason is that the seeder uses the config value `m_shard_ranges.size()` as the number of logical shards, but in the atomizer situation this vector will contain duplicates.

For 2PC this works, since the shard range is defined on the logical cluster level, so `m_shard_ranges` contains an element count equal to the logical shard count:

```
shard_count=4
shard0_count=3
shard0_start=0
shard0_end=63
shard0_0_endpoint="10.0.84.165:5002"
[...]
shard0_1_endpoint="10.10.40.96:5002"
[...]
shard0_2_endpoint="10.20.46.224:5002"
[...]
shard1_count=3
shard1_start=64
shard1_end=127
```

For Atomizer the range value is defined on individual shards, and are duplicated, so `m_shard_ranges` contains an element count equal to the physical shard count:

```
shard0_start=0
shard0_end=63
shard0_endpoint="10.0.84.165:5002"
shard1_start=64
shard1_end=127
shard1_endpoint="10.0.84.111:5002"
[...]
shard4_start=0
shard4_end=63
shard4_endpoint="10.0.84.123:5002"
```

This PR sorts and de-duplicates the vector of shard ranges to get to the correct count.