### PR TITLE
Fix doc and double save in client

### DIFF
--- a/src/uhs/client/client.cpp
+++ b/src/uhs/client/client.cpp
@@ -64,8 +64,6 @@ namespace cbdc {
             m_logger->error("Failed to send mint tx");
         }
 
-        save();
-
         return mint_tx;
     }
 

--- a/src/uhs/client/client.hpp
+++ b/src/uhs/client/client.hpp
@@ -36,8 +36,8 @@ namespace cbdc {
 
         /// \brief Initializes the client.
         ///
-        /// Attempts to load the data files, and creates new ones if they do
-        /// not exist. Establishes connections to the system components.
+        /// Attempts to load the data files and
+        /// establish connections to the system components.
         /// \return true if initialization succeeded.
         auto init() -> bool;
 


### PR DESCRIPTION
This PR contains 2 commits:

### 1. The 1st commit fixes an inaccurate method description

Here's the description of 'client::init':
 https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/client/client.hpp#L37-L42

The implementation shows that `init` does not attempt to create data files if they don't exist:
https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/client/client.cpp#L33-L48

The creation of a wallet data file occurs in  `transaction::wallet::save`:
https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/transaction/wallet.cpp#L307-L327

The creation of a client data file occurs in `client::save_client_state`:
https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/client/client.cpp#L287-L298

### 2. The 2nd commit removes a redundant call
`client::mint` appears to call `save` twice.  As a result, the files written in the 1st call are cleared and the same data is then re-written to them.  The first call to save occurs when `mint` calls `import_transaction`:
https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/client/client.cpp#L57-L70
https://github.com/mit-dci/opencbdc-tx/blob/2b21cc9f857cabaf129a0a413a3ed8825dea2f36/src/uhs/client/client.cpp#L198-L201
The 2nd call occurs in `mint` itself (line 67).  This commit deletes the 2nd call.