### PR TITLE
Unify `Dockerfile` and `configure.sh`, upgrade to LLVM 14, build LevelDB from source

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,8 @@ portability-*,
 cppcoreguidelines-*,
 -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
 readability-*,
-google-explicit-constructor'
+google-explicit-constructor,
+-readability-identifier-length'
 WarningsAsErrors: '*'
 FormatStyle: 'file'
 HeaderFilterRegex: 'hpp'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,52 +3,22 @@ FROM ubuntu:20.04
 # set non-interactive shell
 ENV DEBIAN_FRONTEND noninteractive
 
-# install base packages
-RUN apt update && \
-    apt install -y \
-      build-essential \
-      wget \
-      cmake \
-      libgtest-dev \
-      libgmock-dev \
-      net-tools \
-      lcov \
-      git
+ENV CMAKE_BUILD_TYPE Release
+ENV BUILD_RELEASE 1
 
-# Args
-ARG CMAKE_BUILD_TYPE="Release"
-ARG LEVELDB_VERSION="1.22"
-ARG NURAFT_VERSION="1.3.0"
+RUN mkdir -p /opt/tx-processor/scripts
 
-# Install LevelDB
-RUN wget https://github.com/google/leveldb/archive/${LEVELDB_VERSION}.tar.gz && \
-    tar xzvf ${LEVELDB_VERSION}.tar.gz && \
-    rm -f ${LEVELDB_VERSION}.tar.gz && \
-    cd leveldb-${LEVELDB_VERSION} && \
-    cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 . && \
-    make -j$(nproc) && \
-    make install
-
-# Install NuRaft
-RUN wget https://github.com/eBay/NuRaft/archive/v${NURAFT_VERSION}.tar.gz && \
-    tar xzvf v${NURAFT_VERSION}.tar.gz && \
-    rm v${NURAFT_VERSION}.tar.gz && \
-    cd "NuRaft-${NURAFT_VERSION}" && \
-    ./prepare.sh && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 .. && \
-    make -j$(nproc) static_lib && \
-    cp libnuraft.a /usr/local/lib && \
-    cp -r ../include/libnuraft /usr/local/include
+COPY scripts/configure.sh /opt/tx-processor/scripts/configure.sh
 
 # Set working directory
 WORKDIR /opt/tx-processor
 
+RUN scripts/configure.sh
+
 # Copy source
 COPY . .
 
-# Update submodules and run configure.sh
+# Update submodules
 RUN git submodule init && git submodule update
 
 # Build binaries

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -26,7 +26,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
   # ensure development environment is set correctly for clang
   $SUDO xcode-select -switch /Library/Developer/CommandLineTools
-  brew install leveldb llvm@14 googletest lcov make wget cmake
+  brew install llvm@14 googletest lcov make wget cmake
   CLANG_TIDY=/usr/local/bin/clang-tidy
   if [ ! -L "$CLANG_TIDY" ]; then
     $SUDO ln -s $(brew --prefix)/opt/llvm@14/bin/clang-tidy /usr/local/bin/clang-tidy
@@ -41,63 +41,53 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   apt update
   apt install -y build-essential wget cmake libgtest-dev lcov git software-properties-common rsync
 
-  # GitHub Actions in .github/workflows/validation.yml will attempt to cache and reuse leveldb built in this block.
-  # If a folder called leveldb-1.22 exists, skip the build step and go straight to install.
-  # See https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
-  if [ ! -d "leveldb-1.22-${CMAKE_BUILD_TYPE}" ]; then
-    echo -e "${green}Building LevelDB from sources...${end}"
-    wget https://github.com/google/leveldb/archive/1.22.tar.gz
-    tar xzvf 1.22.tar.gz
-    rm -rf 1.22.tar.gz
-    mv leveldb-1.22 "leveldb-1.22-${CMAKE_BUILD_TYPE}"
-    cd "leveldb-1.22-${CMAKE_BUILD_TYPE}"
-    eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 ."
-    make -j$CPUS
-  else
-    echo -e "${green}Installing LevelDB from cache...${end}"
-    cd "leveldb-1.22-${CMAKE_BUILD_TYPE}"
-  fi
-  make install
-  cd ..
-
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-  add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
-  apt install -y clang-format-14 clang-tidy-14
-  ln -s -f $(which clang-format-14) /usr/local/bin/clang-format
-  ln -s -f $(which clang-tidy-14) /usr/local/bin/clang-tidy
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO apt-key add -
+  $SUDO add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
+  $SUDO apt install -y clang-format-14 clang-tidy-14
+  $SUDO ln -s -f $(which clang-format-14) /usr/local/bin/clang-format
+  $SUDO ln -s -f $(which clang-tidy-14) /usr/local/bin/clang-tidy
 fi
+
+LEVELDB_VERSION="1.23"
+echo -e "${green}Building LevelDB from sources...${end}"
+wget https://github.com/google/leveldb/archive/${LEVELDB_VERSION}.tar.gz
+rm -rf "leveldb-${LEVELDB_VERSION}-${CMAKE_BUILD_TYPE}"
+tar xzvf ${LEVELDB_VERSION}.tar.gz
+rm -rf ${LEVELDB_VERSION}.tar.gz
+mv leveldb-${LEVELDB_VERSION} "leveldb-${LEVELDB_VERSION}-${CMAKE_BUILD_TYPE}"
+cd "leveldb-${LEVELDB_VERSION}-${CMAKE_BUILD_TYPE}"
+eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 ."
+make -j$CPUS
+$SUDO make install
+cd ..
 
 NURAFT_VERSION="1.3.0"
-if [ ! -d "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}" ]; then
-  echo -e "${green}Building NuRaft from sources...${end}"
-  wget https://github.com/eBay/NuRaft/archive/v${NURAFT_VERSION}.tar.gz
-  tar xzvf v${NURAFT_VERSION}.tar.gz
-  rm v${NURAFT_VERSION}.tar.gz
-  mv NuRaft-${NURAFT_VERSION} "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"
-  cd "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"
-  ./prepare.sh
-  if [[ "$BUILD_RELEASE" == "1" ]]; then
-    # If we're doing a release build, remove the examples and tests
-    rm -rf examples tests
-    mkdir examples
-    mkdir tests
-    touch examples/CMakeLists.txt
-    touch tests/CMakeLists.txt
-  fi
-  mkdir -p build
-  cd build
-  eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 .."
-  eval "make -j$CPUS static_lib"
-else
-  echo -e "${green}Installing NuRaft from cache...${end}"
-  cd "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}/build"
+echo -e "${green}Building NuRaft from sources...${end}"
+wget https://github.com/eBay/NuRaft/archive/v${NURAFT_VERSION}.tar.gz
+rm -rf "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"
+tar xzvf v${NURAFT_VERSION}.tar.gz
+rm v${NURAFT_VERSION}.tar.gz
+mv NuRaft-${NURAFT_VERSION} "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"
+cd "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"
+./prepare.sh
+if [[ "$BUILD_RELEASE" == "1" ]]; then
+  # If we're doing a release build, remove the examples and tests
+  rm -rf examples tests
+  mkdir examples
+  mkdir tests
+  touch examples/CMakeLists.txt
+  touch tests/CMakeLists.txt
 fi
+mkdir -p build
+cd build
+eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 .."
+eval "make -j$CPUS static_lib"
 
 echo -e "${green}Copying nuraft to /usr/local"
 $SUDO cp libnuraft.a /usr/local/lib
 $SUDO cp -r ../include/libnuraft /usr/local/include
 
-cd ..
+cd ../..
 
 PYTHON_TIDY=/usr/local/bin/run-clang-tidy.py
 if [ ! -f "${PYTHON_TIDY}" ]; then

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -56,7 +56,7 @@ tar xzvf ${LEVELDB_VERSION}.tar.gz
 rm -rf ${LEVELDB_VERSION}.tar.gz
 mv leveldb-${LEVELDB_VERSION} "leveldb-${LEVELDB_VERSION}-${CMAKE_BUILD_TYPE}"
 cd "leveldb-${LEVELDB_VERSION}-${CMAKE_BUILD_TYPE}"
-eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 ."
+cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DLEVELDB_BUILD_TESTS=0 -DLEVELDB_BUILD_BENCHMARKS=0 -DBUILD_SHARED_LIBS=0 .
 make -j$CPUS
 $SUDO make install
 cd ..
@@ -80,8 +80,8 @@ if [[ "$BUILD_RELEASE" == "1" ]]; then
 fi
 mkdir -p build
 cd build
-eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 .."
-eval "make -j$CPUS static_lib"
+cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DDISABLE_SSL=1 ..
+make -j$CPUS static_lib
 
 echo -e "${green}Copying nuraft to /usr/local"
 $SUDO cp libnuraft.a /usr/local/lib

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -26,10 +26,10 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
   # ensure development environment is set correctly for clang
   $SUDO xcode-select -switch /Library/Developer/CommandLineTools
-  brew install leveldb llvm@11 googletest lcov make wget cmake
+  brew install leveldb llvm@14 googletest lcov make wget cmake
   CLANG_TIDY=/usr/local/bin/clang-tidy
   if [ ! -L "$CLANG_TIDY" ]; then
-    $SUDO ln -s $(brew --prefix)/opt/llvm@11/bin/clang-tidy /usr/local/bin/clang-tidy
+    $SUDO ln -s $(brew --prefix)/opt/llvm@14/bin/clang-tidy /usr/local/bin/clang-tidy
   fi
   GMAKE=/usr/local/bin/gmake
   if [ ! -L "$GMAKE" ]; then
@@ -61,10 +61,10 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   cd ..
 
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-  add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-  apt install -y clang-format-13 clang-tidy-13
-  ln -s -f $(which clang-format-13) /usr/local/bin/clang-format
-  ln -s -f $(which clang-tidy-13) /usr/local/bin/clang-tidy
+  add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
+  apt install -y clang-format-14 clang-tidy-14
+  ln -s -f $(which clang-format-14) /usr/local/bin/clang-format
+  ln -s -f $(which clang-tidy-14) /usr/local/bin/clang-tidy
 fi
 
 NURAFT_VERSION="1.3.0"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,7 +25,7 @@ if [ -n "$whitespace_files" ] || [ -n "$newline_files" ] ; then
 fi
 
 check_format_files=$(git ls-files | grep -E "tools|tests|src|cmake-tests" \
-                     | grep -E ".*pp")
+                     | grep -E "\..*pp")
 clang-format --style=file --Werror --dry-run ${check_format_files[@]}
 
 if ! command -v clang-tidy &>/dev/null; then

--- a/src/util/network/socket.hpp
+++ b/src/util/network/socket.hpp
@@ -35,9 +35,10 @@ namespace cbdc::network {
         socket(socket&&) = delete;
         auto operator=(socket&&) -> socket& = delete;
 
+        virtual ~socket() = default;
+
       private:
         socket();
-        virtual ~socket() = default;
 
         int m_sock_fd{-1};
 

--- a/src/util/rpc/client.hpp
+++ b/src/util/rpc/client.hpp
@@ -75,17 +75,15 @@ namespace cbdc::rpc {
                   response_callback_type response_callback) -> bool {
             auto [request_buf, request_id]
                 = make_request(std::move(request_payload));
-            auto ret = call_raw(
-                std::move(request_buf),
-                request_id,
-                [req_id = request_id, resp_cb = std::move(response_callback)](
-                    std::optional<response_type> resp) {
-                    if(!resp.has_value()) {
-                        return;
-                    }
-                    assert(resp.value().m_header.m_request_id == req_id);
-                    resp_cb(std::move(resp.value().m_payload));
-                });
+            auto ret = call_raw(std::move(request_buf),
+                                request_id,
+                                [resp_cb = std::move(response_callback)](
+                                    std::optional<response_type> resp) {
+                                    if(!resp.has_value()) {
+                                        return;
+                                    }
+                                    resp_cb(std::move(resp.value().m_payload));
+                                });
             return ret;
         }
 


### PR DESCRIPTION
This PR:

1. Removes the custom dependency installation instructions from the `Dockerfile`, using `configure.sh` instead.
2. Ensures the docker image builds all dependencies in release mode.
3. Upgrades LLVM to 14, and fixes issues raised by the upgraded `clang-tidy`. Disables the new `readability-identifier-length` check for now, as large parts of the codebase are not compliant (perhaps this should be an issue?). This is needed to support `NOLINTBEGIN` and `NOLINTEND`, which will be used in a subsequent PR.
4. Simplifies `configure.sh` to remove the dependency cache, which I don't think is used in our current iteration of Github actions, or when building using docker.
5. Builds LevelDB from source on all platforms.
6. Fixes `lint.sh` regex to only include files with the `*pp` extension, rather than any file ending in `pp`.

This probably conflicts with #161.