### PR TITLE
allow disabling sentinel attestations

### DIFF
--- a/src/uhs/twophase/sentinel_2pc/controller.cpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.cpp
@@ -27,13 +27,16 @@ namespace cbdc::sentinel_2pc {
     auto controller::init() -> bool {
         auto skey = m_opts.m_sentinel_private_keys.find(m_sentinel_id);
         if(skey == m_opts.m_sentinel_private_keys.end()) {
-            m_logger->error("No private key specified");
-            return false;
-        }
-        m_privkey = skey->second;
+            if(m_opts.m_attestation_threshold > 0) {
+                m_logger->error("No private key specified");
+                return false;
+            }
+        } else {
+            m_privkey = skey->second;
 
-        auto pubkey = pubkey_from_privkey(m_privkey, m_secp.get());
-        m_logger->info("Sentinel public key:", cbdc::to_string(pubkey));
+            auto pubkey = pubkey_from_privkey(m_privkey, m_secp.get());
+            m_logger->info("Sentinel public key:", cbdc::to_string(pubkey));
+        }
 
         if(!m_coordinator_client.init()) {
             m_logger->error("Failed to start coordinator client");

--- a/src/util/common/config.cpp
+++ b/src/util/common/config.cpp
@@ -443,6 +443,9 @@ namespace cbdc::config {
             const auto sentinel_public_key
                 = cfg.get_string(sentinel_public_key_key);
             if(!sentinel_public_key.has_value()) {
+                if(opts.m_attestation_threshold == 0) {
+                    continue;
+                }
                 return "No public key specified for sentinel "
                      + std::to_string(i) + " (" + sentinel_public_key_key
                      + ")";


### PR DESCRIPTION
- fixes ability to set ```attestation_threshold=0```

Signed-off-by: Jonathan Allen <jonathan.allen@bos.frb.org>