### PR TITLE
Make connection failure fatal only when there is one endpoint

### DIFF
--- a/src/util/rpc/tcp_client.hpp
+++ b/src/util/rpc/tcp_client.hpp
@@ -53,9 +53,11 @@ namespace cbdc::rpc {
 
         /// Initializes the client. Connects to the server endpoints and
         /// starts the response handler thread.
-        /// \return true.
+        /// \return false if there is only one endpoint and connecting failed.
+        ///         Otherwise true.
         [[nodiscard]] auto init() -> bool {
-            if(!m_net.cluster_connect(m_server_endpoints, true)) {
+            if(!m_net.cluster_connect(m_server_endpoints,
+                                      m_server_endpoints.size() <= 1)) {
                 return false;
             }
 

--- a/tests/unit/rpc/tcp_test.cpp
+++ b/tests/unit/rpc/tcp_test.cpp
@@ -126,10 +126,18 @@ TEST(tcp_rpc_test, send_fail_test) {
     auto client = cbdc::rpc::tcp_client<request, response>(
         {{cbdc::network::localhost, 55555},
          {cbdc::network::localhost, 55556}});
-    ASSERT_FALSE(client.init());
+    ASSERT_TRUE(client.init());
 
     auto req = request{0};
     auto resp = client.call(req);
+    ASSERT_FALSE(resp.has_value());
+
+    auto client2 = cbdc::rpc::tcp_client<request, response>(
+        {{cbdc::network::localhost, 55555}});
+    ASSERT_FALSE(client2.init());
+
+    req = request{0};
+    resp = client2.call(req);
     ASSERT_FALSE(resp.has_value());
 }
 


### PR DESCRIPTION
PR #135 introduced a subtle bug where it was impossible to start a configuration where clusters have more than one endpoint. This is because failing to connect to any endpoint is now fatal. However, only the Raft leader of a cluster listens on its endpoint, so we expect the connections to fail in the normal case.

This PR makes connection failure only fatal when there is one endpoint, meaning the leader should always be listening.

In the future this connection logic should probably be more complex, and aware of whether we're connecting to a Raft cluster, checking that at least one endpoint connected. However, in practice it may be better to deal with this elsewhere to remove the constraint on the startup order of components. Maybe it's okay for failure to be a warning in most components rather than a fatal error.