### PR TITLE
Reduce failures to connect from fatal errors to warnings

### DIFF
--- a/src/uhs/atomizer/archiver/controller.cpp
+++ b/src/uhs/atomizer/archiver/controller.cpp
@@ -104,8 +104,7 @@ namespace cbdc::archiver {
     auto controller::init_atomizer_connection() -> bool {
         m_atomizer_network.cluster_connect(m_opts.m_atomizer_endpoints, false);
         if(!m_atomizer_network.connected_to_one()) {
-            m_logger->error("Failed to connect to any atomizers.");
-            return false;
+            m_logger->warn("Failed to connect to any atomizers.");
         }
 
         m_atomizer_handler_thread

--- a/src/uhs/atomizer/atomizer/controller.cpp
+++ b/src/uhs/atomizer/atomizer/controller.cpp
@@ -60,8 +60,7 @@ namespace cbdc::atomizer {
     auto controller::init() -> bool {
         if(!m_watchtower_network.cluster_connect(
                m_opts.m_watchtower_internal_endpoints)) {
-            m_logger->error("Failed to connect to watchtowers.");
-            return false;
+            m_logger->warn("Failed to connect to watchtowers.");
         }
 
         auto raft_params = nuraft::raft_params();

--- a/src/uhs/atomizer/sentinel/controller.cpp
+++ b/src/uhs/atomizer/sentinel/controller.cpp
@@ -40,8 +40,7 @@ namespace cbdc::sentinel {
                            "...");
             auto sock = std::make_unique<network::tcp_socket>();
             if(!sock->connect(shard)) {
-                m_logger->error("failed to connect");
-                return false;
+                m_logger->warn("failed to connect");
             }
 
             const auto peer_id = m_shard_network.add(std::move(sock));

--- a/src/uhs/atomizer/shard/controller.cpp
+++ b/src/uhs/atomizer/shard/controller.cpp
@@ -50,20 +50,17 @@ namespace cbdc::shard {
         }
 
         if(!m_archiver_client.init()) {
-            m_logger->error("Failed to connect to archiver");
-            return false;
+            m_logger->warn("Failed to connect to archiver");
         }
 
         if(!m_watchtower_network.cluster_connect(
                m_opts.m_watchtower_internal_endpoints)) {
-            m_logger->error("Failed to connect to watchtowers.");
-            return false;
+            m_logger->warn("Failed to connect to watchtowers.");
         }
 
         m_atomizer_network.cluster_connect(m_opts.m_atomizer_endpoints, false);
         if(!m_atomizer_network.connected_to_one()) {
-            m_logger->error("Failed to connect to any atomizers");
-            return false;
+            m_logger->warn("Failed to connect to any atomizers");
         }
 
         m_atomizer_client = m_atomizer_network.start_handler([&](auto&& pkt) {

--- a/src/uhs/client/atomizer_client.cpp
+++ b/src/uhs/client/atomizer_client.cpp
@@ -26,13 +26,11 @@ namespace cbdc {
     auto atomizer_client::init_derived() -> bool {
         m_atomizer_network.cluster_connect(m_opts.m_atomizer_endpoints);
         if(!m_atomizer_network.connected_to_one()) {
-            m_logger->error("Failed to connect to any atomizers");
-            return false;
+            m_logger->warn("Failed to connect to any atomizers");
         }
 
         if(!m_wc.init()) {
-            m_logger->error("Failed to initialize watchtower client");
-            return false;
+            m_logger->warn("Failed to initialize watchtower client");
         }
 
         return true;

--- a/src/uhs/client/twophase_client.cpp
+++ b/src/uhs/client/twophase_client.cpp
@@ -23,13 +23,11 @@ namespace cbdc {
 
     auto twophase_client::init_derived() -> bool {
         if(!m_coordinator_client.init()) {
-            m_logger->error("Failed to initialize coordinator client");
-            return false;
+            m_logger->warn("Failed to initialize coordinator client");
         }
 
         if(!m_shard_status_client.init()) {
-            m_logger->error("Failed to initialize shard status client");
-            return false;
+            m_logger->warn("Failed to initialize shard status client");
         }
 
         return true;

--- a/src/uhs/twophase/sentinel_2pc/controller.cpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.cpp
@@ -39,8 +39,7 @@ namespace cbdc::sentinel_2pc {
         }
 
         if(!m_coordinator_client.init()) {
-            m_logger->error("Failed to start coordinator client");
-            return false;
+            m_logger->warn("Failed to start coordinator client");
         }
 
         for(const auto& ep : m_opts.m_sentinel_endpoints) {
@@ -51,8 +50,7 @@ namespace cbdc::sentinel_2pc {
                 std::vector<network::endpoint_t>{ep},
                 m_logger);
             if(!client->init()) {
-                m_logger->error("Failed to start sentinel client");
-                return false;
+                m_logger->warn("Failed to start sentinel client");
             }
             m_sentinel_clients.emplace_back(std::move(client));
         }

--- a/tests/unit/archiver_test.cpp
+++ b/tests/unit/archiver_test.cpp
@@ -165,12 +165,11 @@ TEST_F(ArchiverTest, archiver_terminate) {
     ASSERT_FALSE(terminating_archiver->running());
 }
 
-// We only test the atomizer initialization in failure, given that
-// for a succesful init we need a running atomizer, which by definition
-// is an integration test, and as such needs to happen in the integration
-// test suite, not here.
+// TODO: To test for a succesful init we need a running atomizer, which by
+// definition is an integration test, and as such this test needs to either be
+// an integration test, or the atomizer needs to be mocked.
 TEST_F(ArchiverTest, archiver_atomizer_init_failure) {
-    ASSERT_FALSE(m_archiver->init_atomizer_connection());
+    ASSERT_TRUE(m_archiver->init_atomizer_connection());
 }
 
 // Test if the archiver properly initializes its server interface
@@ -283,10 +282,12 @@ TEST_F(ArchiverTest, get_block_non_existent) {
 
 // Test if the archiver is functional after calling the main init function
 TEST_F(ArchiverTest, init) {
-    // init should return false because we can't connect to an atomizer
-    // but it should still be functional given that the local initialization
-    // (level db, block height, sample collection) is done first.
-    ASSERT_FALSE(m_archiver->init());
+    // init should return true even though we can't connect to an atomizer to
+    // eliminate any startup order requirements.
+    // However, it should still be functional given that the local
+    // initialization (level db, block height, sample collection) is done
+    // first.
+    ASSERT_TRUE(m_archiver->init());
     m_archiver->digest_block(m_dummy_blocks[0]);
     auto blk = m_archiver->get_block(1);
     ASSERT_TRUE(blk.has_value());

--- a/tests/unit/sentinel_2pc/controller_test.cpp
+++ b/tests/unit/sentinel_2pc/controller_test.cpp
@@ -185,8 +185,8 @@ TEST_F(sentinel_2pc_test, bad_coordinator_endpoint) {
                                                                 m_logger);
 
     // Check that the controller with the invalid coordinator endpoint
-    // fails to initialize correctly.
-    ASSERT_FALSE(ctl->init());
+    // still initializes correctly.
+    ASSERT_TRUE(ctl->init());
 }
 
 TEST_F(sentinel_2pc_test, bad_sentinel_client_endpoint) {
@@ -197,13 +197,13 @@ TEST_F(sentinel_2pc_test, bad_sentinel_client_endpoint) {
     auto client = cbdc::sentinel::rpc::client(bad_endpoints, m_logger);
     ASSERT_FALSE(client.init());
 
-    // Test that the controller fails to initialize when given a bad endpoint
+    // Test that the controller initializes even when given a bad endpoint
     // for a sentinel client.
     m_opts.m_sentinel_endpoints.emplace_back(bad_endpoint);
     auto ctl = std::make_unique<cbdc::sentinel_2pc::controller>(0,
                                                                 m_opts,
                                                                 m_logger);
-    ASSERT_FALSE(ctl->init());
+    ASSERT_TRUE(ctl->init());
 }
 
 TEST_F(sentinel_2pc_test, bad_rpc_server_endpoint) {

--- a/tools/bench/atomizer-cli-watchtower.cpp
+++ b/tools/bench/atomizer-cli-watchtower.cpp
@@ -82,8 +82,7 @@ auto main(int argc, char** argv) -> int {
 
     atomizer_network.cluster_connect(cfg.m_atomizer_endpoints, false);
     if(!atomizer_network.connected_to_one()) {
-        log->error("Failed to connect to any atomizers");
-        return -1;
+        log->warn("Failed to connect to any atomizers");
     }
 
     static std::atomic_bool atomizer_network_running = true;
@@ -112,8 +111,7 @@ auto main(int argc, char** argv) -> int {
         cfg.m_watchtower_client_endpoints[our_watchtower]);
 
     if(!watchtower_client->init()) {
-        log->error("Failed to connect to watchtower.");
-        return -1;
+        log->warn("Failed to connect to watchtower.");
     }
 
     auto blocking_watchtower_client
@@ -121,8 +119,7 @@ auto main(int argc, char** argv) -> int {
             cfg.m_watchtower_client_endpoints[our_watchtower]);
 
     if(!blocking_watchtower_client->init()) {
-        log->error("Failed to connect to watchtower.");
-        return -1;
+        log->warn("Failed to connect to watchtower.");
     }
 
     cbdc::transaction::wallet wal;
@@ -327,8 +324,7 @@ auto main(int argc, char** argv) -> int {
             auto bwc = cbdc::watchtower::blocking_client{
                 cfg.m_watchtower_client_endpoints[our_watchtower]};
             if(!bwc.init()) {
-                log->error("Failed to connect to watchtower.");
-                return -1;
+                log->warn("Failed to connect to watchtower.");
             }
             if(atomizer_network.send_to_one(cbdc::atomizer::request{msg})) {
                 log->info("Sent mint TX to atomizer. ID:",

--- a/tools/bench/twophase_gen.cpp
+++ b/tools/bench/twophase_gen.cpp
@@ -70,8 +70,7 @@ auto main(int argc, char** argv) -> int {
         auto coordinator_client
             = cbdc::coordinator::rpc::client(cfg.m_coordinator_endpoints[0]);
         if(!coordinator_client.init()) {
-            logger->error("Failed to connect to coordinator");
-            return -1;
+            logger->warn("Failed to connect to coordinator");
         }
 
         auto mint_tx = wallet.mint_new_coins(cfg.m_initial_mint_count,
@@ -122,15 +121,13 @@ auto main(int argc, char** argv) -> int {
         cfg.m_shard_ranges,
         lookup_timeout);
     if(!status_client.init()) {
-        logger->error("Failed to connect to shard read-only endpoints");
-        return -1;
+        logger->warn("Failed to connect to shard read-only endpoints");
     }
 
     auto sentinel_client
         = cbdc::sentinel::rpc::client(cfg.m_sentinel_endpoints, logger);
     if(!sentinel_client.init()) {
-        logger->error("Failed to connect to sentinel");
-        return -1;
+        logger->warn("Failed to connect to sentinel");
     }
 
     auto confirmed_txs = std::queue<cbdc::transaction::full_tx>();


### PR DESCRIPTION
Follow up from #168. This PR reduces all failures to connect from fatal errors to warnings. This should eliminate the startup order requirement of the system components.

I think I got them all, but it's possible I missed one.