### PR TITLE
Remove disabling RTTI message from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ find_library(NURAFT_LIBRARY nuraft REQUIRED)
 find_library(GTEST_LIBRARY gtest REQUIRED)
 find_library(GTEST_MAIN_LIBRARY gtest_main REQUIRED)
 
-message("Disabling Run Time Type Information (RTTI) features.")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 include_directories(3rdparty 3rdparty/secp256k1/include /usr/local/include /opt/homebrew/include)


### PR DESCRIPTION
The message `Disabling Run Time Type Information (RTTI) features.` was introduced by 3426b09 and is removed in this PR. It's the only custom message we emit from CMake, and gets printed every time you build. The message seems a little unnecessary (and perhaps confusing), so I propose removing it.