### PR TITLE
Replace usage of std::cout with the logger

### DIFF
--- a/src/uhs/atomizer/atomizer/controller.cpp
+++ b/src/uhs/atomizer/atomizer/controller.cpp
@@ -230,8 +230,7 @@ namespace cbdc::atomizer {
     void controller::err_return_handler(raft::result_type& r,
                                         nuraft::ptr<std::exception>& err) {
         if(err) {
-            std::cout << "Exception handling log entry: " << err->what()
-                      << std::endl;
+            m_logger->warn("Exception handling log entry:", err->what());
             return;
         }
 

--- a/src/util/raft/node.cpp
+++ b/src/util/raft/node.cpp
@@ -55,13 +55,12 @@ namespace cbdc::raft {
             return false;
         }
 
-        std::cout << "Waiting for raft initialization";
+        m_raft_logger->info("Waiting for raft initialization");
         static constexpr auto wait_time = std::chrono::milliseconds(100);
         while(!m_raft_instance->is_initialized()) {
-            std::cout << "." << std::flush;
             std::this_thread::sleep_for(wait_time);
         }
-        std::cout << std::endl;
+        m_raft_logger->info("Raft initialization complete");
 
         return true;
     }


### PR DESCRIPTION
This PR removes a couple of instances where we still used `std::cout` to directly emit log messages, using the logger instead.