### PR TITLE
Make cross-sentinel connection failures non-fatal

### DIFF
--- a/src/uhs/sentinel/client.cpp
+++ b/src/uhs/sentinel/client.cpp
@@ -15,8 +15,8 @@ namespace cbdc::sentinel::rpc {
         : m_logger(std::move(logger)),
           m_client(std::move(endpoints)) {}
 
-    auto client::init() -> bool {
-        if(!m_client.init()) {
+    auto client::init(std::optional<bool> error_fatal) -> bool {
+        if(!m_client.init(error_fatal)) {
             m_logger->error("Failed to initialize sentinel RPC client");
             return false;
         }

--- a/src/uhs/sentinel/client.hpp
+++ b/src/uhs/sentinel/client.hpp
@@ -31,8 +31,11 @@ namespace cbdc::sentinel::rpc {
         auto operator=(client&&) -> client& = delete;
 
         /// Initializes the client. Establishes a connection to the sentinel.
+        /// \param error_fatal treat connection errors as fatal. See
+        ///                    tcp_client::init for further explanation.
         /// \return true if initialization succeeded.
-        auto init() -> bool;
+        /// \see \ref cbdc::rpc::tcp_client::init(std::optional<bool>)
+        auto init(std::optional<bool> error_fatal = std::nullopt) -> bool;
 
         /// Result type from execute_transaction.
         using execute_result_type

--- a/src/uhs/twophase/sentinel_2pc/controller.cpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.cpp
@@ -49,7 +49,7 @@ namespace cbdc::sentinel_2pc {
             auto client = std::make_unique<sentinel::rpc::client>(
                 std::vector<network::endpoint_t>{ep},
                 m_logger);
-            if(!client->init()) {
+            if(!client->init(false)) {
                 m_logger->warn("Failed to start sentinel client");
             }
             m_sentinel_clients.emplace_back(std::move(client));


### PR DESCRIPTION
Follow-up on #135 , #167 and #168

This sequence of updates now causes the connection between sentinels, used for requesting attestations from other sentinels, to silently fail. Even though the `false` return value from `tcp_client::init` is now considered a warning and the sentinel continues running, the connection is not working because the handler thread never gets started. So now, RPC calls from sentinel to sentinel fail at runtime.

The first sentinel in the startup sequence could potentially have no working connections and get stuck in endless retry loops.

Sentinel to sentinel communication is actually a situation where `cluster_connect(endpoints, false)` should be used even with a single endpoint, since it's fine for one or more sentinels to be unreachable temporarily (we'll just use another). But because `m_server_endpoints.size() <= 1` is used as parameter to cluster_connect that behavior is impossible.

The reason sentinel->sentinel communication uses clusters of 1 is because the sentinel has to control which other sentinels are called to prevent getting more than one attestation from the same sentinel. So we can't just build a cluster of all other sentinels and use `send_to_one()`

My suggestion, through this PR, is to add an optional boolean overload to `init()` that allows you to set the `error_fatal` parameter of `cluster_connect` manually.



