### PR TITLE
Use logging::log and remove use of std::cerr in raft::node

### DIFF
--- a/src/util/raft/node.hpp
+++ b/src/util/raft/node.hpp
@@ -117,6 +117,8 @@ namespace cbdc::raft {
 
         nuraft::asio_service::options m_asio_opt;
         nuraft::raft_server::init_options m_init_opts;
+
+        std::shared_ptr<logging::log> m_log;
     };
 }
 


### PR DESCRIPTION
Fixes #180.

This PR removes the use of `std::cerr` in `raft::node`. It also replaces usage of the NuRaft console logger, instead using our own logger class.