### PR TITLE
Performance fixes for sentinel attestations

### DIFF
--- a/src/uhs/twophase/locking_shard/controller.cpp
+++ b/src/uhs/twophase/locking_shard/controller.cpp
@@ -8,6 +8,7 @@
 #include "format.hpp"
 #include "state_machine.hpp"
 #include "status_client.hpp"
+#include "uhs/transaction/validation.hpp"
 #include "util/rpc/tcp_server.hpp"
 #include "util/serialization/format.hpp"
 
@@ -16,7 +17,7 @@
 namespace cbdc::locking_shard {
     controller::controller(size_t shard_id,
                            size_t node_id,
-                           config::options opts,
+                           const cbdc::config::options& opts,
                            std::shared_ptr<logging::log> logger)
         : m_opts(std::move(opts)),
           m_logger(std::move(logger)),
@@ -116,6 +117,14 @@ namespace cbdc::locking_shard {
         -> nuraft::cb_func::ReturnCode {
         if(type == nuraft::cb_func::Type::BecomeFollower) {
             m_logger->warn("Became follower, stopping listener");
+
+            m_running = false;
+            for(auto& t : m_validation_threads) {
+                if(t.joinable()) {
+                    t.join();
+                }
+            }
+            m_validation_threads.clear();
             m_server.reset();
             return nuraft::cb_func::ReturnCode::Ok;
         }
@@ -123,11 +132,83 @@ namespace cbdc::locking_shard {
             m_logger->warn("Became leader, starting listener");
             m_server = std::make_unique<decltype(m_server)::element_type>(
                 m_opts.m_locking_shard_endpoints[m_shard_id][m_node_id]);
-            m_server->register_raft_node(m_raft_serv);
+            m_server->register_raft_node(
+                m_raft_serv,
+                [&, this](cbdc::buffer buf,
+                          cbdc::raft::rpc::validation_callback cb) {
+                    return enqueue_validation(std::move(buf), std::move(cb));
+                });
+
+            auto n_threads = std::thread::hardware_concurrency();
+            for(size_t i = 0; i < n_threads; i++) {
+                m_validation_threads.emplace_back([&, this]() {
+                    validation_worker();
+                });
+            }
+
             if(!m_server->init()) {
                 m_logger->fatal("Couldn't start message handler server");
             }
         }
         return nuraft::cb_func::ReturnCode::Ok;
+    }
+
+    void controller::validation_worker() {
+        while(m_running) {
+            auto v = validation_request();
+            if(m_validation_queue.pop(v)) {
+                auto [req, cb] = v;
+                validate_request(std::move(req), std::move(cb));
+            }
+        }
+    }
+
+    auto
+    controller::enqueue_validation(cbdc::buffer buf,
+                                   cbdc::raft::rpc::validation_callback cb)
+        -> bool {
+        m_validation_queue.push({std::move(buf), std::move(cb)});
+        return true;
+    }
+
+    auto controller::validate_request(cbdc::buffer buf,
+                                      cbdc::raft::rpc::validation_callback cb)
+        -> bool {
+        auto maybe_req
+            = cbdc::from_buffer<cbdc::rpc::request<rpc::request>>(buf);
+        auto valid = true;
+        if(maybe_req) {
+            valid = std::visit(
+                overloaded{
+                    [&](rpc::lock_params&& params) -> bool {
+                        auto result = true;
+                        for(auto&& t : params) {
+                            if(!transaction::validation::check_attestations(
+                                   t.m_tx,
+                                   m_opts.m_sentinel_public_keys,
+                                   m_opts.m_attestation_threshold)) {
+                                m_logger->warn(
+                                    "Received invalid compact transaction",
+                                    to_string(t.m_tx.m_id));
+                                result = false;
+                                break;
+                            }
+                        }
+
+                        return result;
+                    },
+                    [&](rpc::apply_params&&) -> bool {
+                        return true;
+                    },
+                    [&](rpc::discard_params&&) -> bool {
+                        return true;
+                    }},
+                std::move(maybe_req->m_payload.m_params));
+        } else {
+            valid = false;
+        }
+
+        cb(std::move(buf), valid);
+        return true;
     }
 }

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -103,21 +103,11 @@ namespace cbdc::locking_shard {
 
     auto locking_shard::check_and_lock_tx(const tx& t) -> bool {
         bool success{true};
-        if(!transaction::validation::check_attestations(
-               t.m_tx,
-               m_opts.m_sentinel_public_keys,
-               m_opts.m_attestation_threshold)) {
-            m_logger->warn("Received invalid compact transaction",
-                           to_string(t.m_tx.m_id));
-            success = false;
-        }
-        if(success) {
-            for(const auto& uhs_id : t.m_tx.m_inputs) {
-                if(hash_in_shard_range(uhs_id)
-                   && m_uhs.find(uhs_id) == m_uhs.end()) {
-                    success = false;
-                    break;
-                }
+        for(const auto& uhs_id : t.m_tx.m_inputs) {
+            if(hash_in_shard_range(uhs_id)
+               && m_uhs.find(uhs_id) == m_uhs.end()) {
+                success = false;
+                break;
             }
         }
         if(success) {

--- a/src/uhs/twophase/sentinel_2pc/controller.cpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.cpp
@@ -80,6 +80,22 @@ namespace cbdc::sentinel_2pc {
             return false;
         }
 
+        auto n_threads = std::thread::hardware_concurrency() / 2;
+        if(n_threads < 1) {
+            n_threads = 1;
+        }
+        for(size_t i = 0; i < n_threads; i++) {
+            m_validation_threads.emplace_back([&]() {
+                validation_worker();
+            });
+        }
+
+        for(size_t i = 0; i < n_threads; i++) {
+            m_attestation_threads.emplace_back([&]() {
+                attestation_worker();
+            });
+        }
+
         m_rpc_server = std::make_unique<decltype(m_rpc_server)::element_type>(
             this,
             std::move(rpc_server));
@@ -87,33 +103,67 @@ namespace cbdc::sentinel_2pc {
         return true;
     }
 
+    void controller::validation_worker() {
+        while(m_running) {
+            auto v = queued_validation();
+            if(m_validation_queue.pop(v)) {
+                auto [tx, cb] = v;
+                cb(std::move(tx), transaction::validation::check_tx(tx));
+            }
+        }
+    }
+
+    auto controller::validate_tx(const transaction::full_tx& tx,
+                                 validation_callback cb) -> bool {
+        m_validation_queue.push({std::move(tx), std::move(cb)});
+        return true;
+    }
+
+    void controller::attestation_worker() {
+        while(m_running) {
+            auto v = queued_attestation();
+            if(m_attestation_queue.pop(v)) {
+                auto [tx, cb] = v;
+                auto compact_tx = cbdc::transaction::compact_tx(tx);
+                cb(std::move(tx), compact_tx.sign(m_secp.get(), m_privkey));
+            }
+        }
+    }
+
+    auto controller::attest_tx(const transaction::full_tx& tx,
+                               attestation_callback cb) -> bool {
+        m_attestation_queue.push({std::move(tx), std::move(cb)});
+        return true;
+    }
+
     auto controller::execute_transaction(
         transaction::full_tx tx,
         execute_result_callback_type result_callback) -> bool {
-        const auto validation_err = transaction::validation::check_tx(tx);
-        if(validation_err.has_value()) {
-            auto tx_id = transaction::tx_id(tx);
-            m_logger->debug(
-                "Rejected (",
-                transaction::validation::to_string(validation_err.value()),
-                ")",
-                to_string(tx_id));
-            result_callback(cbdc::sentinel::execute_response{
-                cbdc::sentinel::tx_status::static_invalid,
-                validation_err});
-            return true;
-        }
+        return controller::validate_tx(
+            std::move(tx),
+            [&, result_callback](
+                const transaction::full_tx& tx2,
+                std::optional<cbdc::transaction::validation::tx_error> err) {
+                auto tx_id = cbdc::transaction::tx_id(tx2);
+                if(err.has_value()) {
+                    m_logger->debug(
+                        "Rejected (",
+                        transaction::validation::to_string(err.value()),
+                        ")",
+                        to_string(tx_id));
+                    result_callback(cbdc::sentinel::execute_response{
+                        cbdc::sentinel::tx_status::static_invalid,
+                        err});
+                    return;
+                }
 
-        auto compact_tx = cbdc::transaction::compact_tx(tx);
-
-        if(m_opts.m_attestation_threshold > 0) {
-            auto attestation = compact_tx.sign(m_secp.get(), m_privkey);
-            compact_tx.m_attestations.insert(attestation);
-        }
-
-        gather_attestations(tx, std::move(result_callback), compact_tx, {});
-
-        return true;
+                auto compact_tx = cbdc::transaction::compact_tx(tx2);
+                gather_attestations(std::move(tx2),
+                                    std::move(result_callback),
+                                    compact_tx,
+                                    {});
+                return;
+            });
     }
 
     void
@@ -135,15 +185,23 @@ namespace cbdc::sentinel_2pc {
     auto controller::validate_transaction(
         transaction::full_tx tx,
         validate_result_callback_type result_callback) -> bool {
-        const auto validation_err = transaction::validation::check_tx(tx);
-        if(validation_err.has_value()) {
-            result_callback(std::nullopt);
-            return true;
-        }
-        auto compact_tx = cbdc::transaction::compact_tx(tx);
-        auto attestation = compact_tx.sign(m_secp.get(), m_privkey);
-        result_callback(std::move(attestation));
-        return true;
+        return controller::validate_tx(
+            std::move(tx),
+            [&, result_callback](
+                const transaction::full_tx& tx2,
+                std::optional<cbdc::transaction::validation::tx_error> err) {
+                if(err.has_value()) {
+                    result_callback(std::nullopt);
+                    return;
+                }
+                controller::attest_tx(
+                    std::move(tx2),
+                    [&, result_callback](
+                        const transaction::full_tx& /* tx3 */,
+                        std::optional<cbdc::sentinel::validate_response> res) {
+                        result_callback(std::move(res));
+                    });
+            });
     }
 
     void controller::validate_result_handler(
@@ -165,14 +223,44 @@ namespace cbdc::sentinel_2pc {
                             std::move(requested));
     }
 
+    void controller::stop() {
+        m_running = false;
+        for(auto& t : m_validation_threads) {
+            if(t.joinable()) {
+                t.join();
+            }
+        }
+
+        for(auto& t : m_attestation_threads) {
+            if(t.joinable()) {
+                t.join();
+            }
+        }
+    }
+
     void controller::gather_attestations(
         const transaction::full_tx& tx,
         execute_result_callback_type result_callback,
         const transaction::compact_tx& ctx,
         std::unordered_set<size_t> requested) {
         if(ctx.m_attestations.size() < m_opts.m_attestation_threshold) {
+            if(ctx.m_attestations.size() == 0) {
+                // Self-attest first
+                controller::attest_tx(
+                    std::move(tx),
+                    [&, ctx, result_callback](const transaction::full_tx& tx2,
+                                              validate_result res) {
+                        validate_result_handler(res,
+                                                tx2,
+                                                result_callback,
+                                                ctx,
+                                                {});
+                    });
+
+                return;
+            }
             auto success = false;
-            while(!success) {
+            while(!success && m_running) {
                 auto sentinel_id = m_dist(m_rand);
                 if(requested.find(sentinel_id) != requested.end()) {
                     continue;
@@ -201,14 +289,16 @@ namespace cbdc::sentinel_2pc {
     void
     controller::send_compact_tx(const transaction::compact_tx& ctx,
                                 execute_result_callback_type result_callback) {
-        auto cb =
-            [&, res_cb = std::move(result_callback)](std::optional<bool> res) {
-                result_handler(res, res_cb);
-            };
+        auto cb = [&, this, ctx, res_cb = std::move(result_callback)](
+                      std::optional<bool> res) {
+            result_handler(res, res_cb);
+        };
 
-        // TODO: add a "retry" error response to offload sentinels from this
+        // TODO: add a "retry" error response to offload sentinels from
+        // this
         //       infinite retry responsibility.
-        while(!m_coordinator_client.execute_transaction(ctx, cb)) {
+        while(!m_coordinator_client.execute_transaction(ctx, cb)
+              && m_running) {
             // TODO: the network currently doesn't provide a callback for
             //       reconnection events so we have to sleep here to
             //       prevent a needless spin. Instead, add such a callback

--- a/src/uhs/twophase/sentinel_2pc/controller.hpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.hpp
@@ -13,6 +13,7 @@
 #include "uhs/sentinel/format.hpp"
 #include "uhs/transaction/messages.hpp"
 #include "uhs/twophase/coordinator/client.hpp"
+#include "util/common/blocking_queue.hpp"
 #include "util/common/config.hpp"
 #include "util/common/hashmap.hpp"
 #include "util/network/connection_manager.hpp"
@@ -66,7 +67,22 @@ namespace cbdc::sentinel_2pc {
                              validate_result_callback_type result_callback)
             -> bool override;
 
+        /// Cleanly stop the controller
+        void stop();
+
       private:
+        using validation_callback = std::function<void(
+            const transaction::full_tx&,
+            std::optional<cbdc::transaction::validation::tx_error>)>;
+        using queued_validation
+            = std::pair<transaction::full_tx, validation_callback>;
+
+        using attestation_callback = std::function<void(
+            const transaction::full_tx&,
+            std::optional<cbdc::sentinel::validate_response>)>;
+        using queued_attestation
+            = std::pair<transaction::full_tx, attestation_callback>;
+
         static void result_handler(std::optional<bool> res,
                                    const execute_result_callback_type& res_cb);
 
@@ -85,9 +101,23 @@ namespace cbdc::sentinel_2pc {
         void send_compact_tx(const transaction::compact_tx& ctx,
                              execute_result_callback_type result_callback);
 
+        auto validate_tx(const transaction::full_tx& tx,
+                         validation_callback cb) -> bool;
+        void validation_worker();
+
+        auto attest_tx(const transaction::full_tx& tx, attestation_callback cb)
+            -> bool;
+        void attestation_worker();
+
         uint32_t m_sentinel_id;
         cbdc::config::options m_opts;
         std::shared_ptr<logging::log> m_logger;
+
+        blocking_queue<queued_validation> m_validation_queue{};
+        std::vector<std::thread> m_validation_threads{};
+
+        blocking_queue<queued_attestation> m_attestation_queue{};
+        std::vector<std::thread> m_attestation_threads{};
 
         std::unique_ptr<cbdc::sentinel::rpc::async_server> m_rpc_server;
 
@@ -106,6 +136,8 @@ namespace cbdc::sentinel_2pc {
         std::uniform_int_distribution<size_t> m_dist{};
 
         privkey_t m_privkey{};
+
+        std::atomic<bool> m_running{true};
     };
 }
 

--- a/src/uhs/twophase/sentinel_2pc/sentineld_2pc.cpp
+++ b/src/uhs/twophase/sentinel_2pc/sentineld_2pc.cpp
@@ -63,6 +63,8 @@ auto main(int argc, char** argv) -> int {
 
     logger->info("Shutting down...");
 
+    ctl.stop();
+
     return 0;
 }
 // LCOV_EXCL_STOP

--- a/src/uhs/twophase/sentinel_2pc/server.cpp
+++ b/src/uhs/twophase/sentinel_2pc/server.cpp
@@ -11,22 +11,44 @@ namespace cbdc::sentinel::rpc {
         std::unique_ptr<cbdc::rpc::async_server<request, response>> srv)
         : m_impl(impl),
           m_srv(std::move(srv)) {
+        m_processing_thread = std::thread([this]() {
+            process();
+        });
         m_srv->register_handler_callback(
             [&](const request& req,
                 async_interface::result_callback_type callback) {
-                auto res = std::visit(
-                    overloaded{[&](execute_request e_req) {
-                                   return m_impl->execute_transaction(
-                                       std::move(e_req),
-                                       callback);
-                               },
-                               [&](validate_request v_req) {
-                                   return m_impl->validate_transaction(
-                                       std::move(v_req),
-                                       callback);
-                               }},
-                    req);
-                return res;
+                auto req_item = request_queue_t{req, callback};
+                m_request_queue.push(req_item);
+                return true;
             });
+    }
+    bool operator<(const request_queue_t& a, const request_queue_t& b) {
+        // Prioritize validate requests over execute requests
+        return (std::holds_alternative<validate_request>(a.m_req)
+                && std::holds_alternative<execute_request>(b.m_req));
+    }
+    async_server::~async_server() {
+        m_running = false;
+        if(m_processing_thread.joinable()) {
+            m_processing_thread.join();
+        }
+    }
+    void async_server::process() {
+        auto q = request_queue_t();
+        while(m_running) {
+            if(m_request_queue.pop(q)) {
+                std::visit(overloaded{[&](execute_request e_req) {
+                                          return m_impl->execute_transaction(
+                                              std::move(e_req),
+                                              q.m_cb);
+                                      },
+                                      [&](validate_request v_req) {
+                                          return m_impl->validate_transaction(
+                                              std::move(v_req),
+                                              q.m_cb);
+                                      }},
+                           q.m_req);
+            }
+        }
     }
 }

--- a/src/uhs/twophase/sentinel_2pc/server.hpp
+++ b/src/uhs/twophase/sentinel_2pc/server.hpp
@@ -8,10 +8,17 @@
 
 #include "uhs/sentinel/async_interface.hpp"
 #include "uhs/transaction/messages.hpp"
+#include "util/common/blocking_queue.hpp"
 #include "util/rpc/async_server.hpp"
 #include "util/rpc/format.hpp"
 
 namespace cbdc::sentinel::rpc {
+    struct request_queue_t {
+        request m_req;
+        async_interface::result_callback_type m_cb;
+    };
+
+    bool operator<(const request_queue_t& a, const request_queue_t& b);
     /// Asynchronous RPC server for a sentinel.
     class async_server {
       public:
@@ -25,9 +32,18 @@ namespace cbdc::sentinel::rpc {
                                    //      implementation
             std::unique_ptr<cbdc::rpc::async_server<request, response>> srv);
 
+        ~async_server();
+
       private:
+        void process();
+
         async_interface* m_impl;
         std::unique_ptr<cbdc::rpc::async_server<request, response>> m_srv;
+
+        blocking_priority_queue<request_queue_t, std::less<request_queue_t>>
+            m_request_queue{};
+        std::thread m_processing_thread;
+        std::atomic<bool> m_running = true;
     };
 }
 

--- a/src/util/raft/rpc_server.hpp
+++ b/src/util/raft/rpc_server.hpp
@@ -10,6 +10,10 @@
 #include "util/rpc/async_server.hpp"
 
 namespace cbdc::raft::rpc {
+    using validation_callback = std::function<void(buffer, bool)>;
+    using validate_function_type
+        = std::function<bool(buffer, validation_callback)>;
+
     /// Generic RPC server for raft nodes for which the replicated state
     /// machine handles the request processing logic. Replicates
     /// requests to the cluster which executes them via its state machine. Once
@@ -22,7 +26,27 @@ namespace cbdc::raft::rpc {
         /// \param impl pointer to the raft node.
         /// \see cbdc::rpc::server
         void register_raft_node(std::shared_ptr<node> impl) {
+            register_raft_node(impl, std::nullopt);
+        }
+
+        /// Registers the raft node whose state machine handles RPC requests
+        /// for this server.
+        /// \param impl pointer to the raft node.
+        /// \param validate optional method to validate requests before
+        /// replicating them to the raft cluster
+        /// \see cbdc::rpc::server
+        void
+        register_raft_node(std::shared_ptr<node> impl,
+                           std::optional<validate_function_type> validate) {
             m_impl = std::move(impl);
+            if(validate.has_value()) {
+                m_validate_func = std::move(validate.value());
+            } else {
+                m_validate_func = [&](buffer b, validation_callback cb) {
+                    cb(std::move(b), true);
+                    return true;
+                };
+            }
             cbdc::rpc::raw_async_server::register_handler_callback(
                 [&](buffer req, response_callback_type resp_cb) {
                     return request_handler(std::move(req), std::move(resp_cb));
@@ -33,6 +57,7 @@ namespace cbdc::raft::rpc {
 
       private:
         std::shared_ptr<node> m_impl;
+        validate_function_type m_validate_func;
 
         using response_callback_type =
             typename cbdc::rpc::raw_async_server::response_callback_type;
@@ -44,35 +69,43 @@ namespace cbdc::raft::rpc {
                 return false;
             }
 
-            // TODO: make network and sockets generic over the buffer type so
-            //       these copy operations for the request and response to get
-            //       over the nuraft/cbdc boundary are not needed.
-            auto new_log = nuraft::buffer::alloc(request_buf.size());
-            nuraft::buffer_serializer bs(new_log);
-            bs.put_raw(request_buf.data(), request_buf.size());
-
-            auto success = m_impl->replicate(
-                new_log,
-                [&, resp_cb = std::move(response_callback), req_buf = new_log](
-                    result_type& r,
-                    nuraft::ptr<std::exception>& err) {
-                    if(err) {
-                        resp_cb(std::nullopt);
+            return m_validate_func(
+                std::move(request_buf),
+                [&, res_cb = std::move(response_callback)](buffer buf2,
+                                                           bool valid) {
+                    if(!valid) {
+                        res_cb(std::nullopt);
                         return;
                     }
 
-                    const auto res = r.get();
-                    if(!res) {
-                        resp_cb(std::nullopt);
-                        return;
-                    }
+                    auto new_log = nuraft::buffer::alloc(buf2.size());
+                    nuraft::buffer_serializer bs(new_log);
+                    bs.put_raw(buf2.data(), buf2.size());
 
-                    auto resp_pkt = cbdc::buffer();
-                    resp_pkt.append(res->data_begin(), res->size());
-                    resp_cb(std::move(resp_pkt));
+                    auto success = m_impl->replicate(
+                        new_log,
+                        [&, resp_cb = std::move(res_cb), req_buf = new_log](
+                            result_type& r,
+                            nuraft::ptr<std::exception>& err) {
+                            if(err) {
+                                resp_cb(std::nullopt);
+                                return;
+                            }
+
+                            const auto res = r.get();
+                            if(!res) {
+                                resp_cb(std::nullopt);
+                                return;
+                            }
+
+                            auto resp_pkt = cbdc::buffer();
+                            resp_pkt.append(res->data_begin(), res->size());
+                            resp_cb(std::move(resp_pkt));
+                        });
+                    if(!success) {
+                        res_cb(std::nullopt);
+                    }
                 });
-
-            return success;
         }
     };
 }


### PR DESCRIPTION
This PR adds performance improvements to the sentinel attestations:

- Validation and attestation happen in parallel threads in the sentinel
- Attestation requests are prioritized by sentinels such that the end-to-end latency of transactions reduces under high(er) load: incoming transactions will wait until existing transactions pending attestation are completed.
- Validation of attestations happens in parallel in the coordinator
- Validation of attestations happens in parallel and outside of the state machine (before replication) in the shard.