### PR TITLE
Fix missing dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_library(LEVELDB_LIBRARY leveldb REQUIRED)
 find_library(NURAFT_LIBRARY nuraft REQUIRED)
 find_library(GTEST_LIBRARY gtest REQUIRED)
 find_library(GTEST_MAIN_LIBRARY gtest_main REQUIRED)
+find_library(SNAPPY_LIBRARY snappy REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -26,7 +26,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
   # ensure development environment is set correctly for clang
   $SUDO xcode-select -switch /Library/Developer/CommandLineTools
-  brew install llvm@14 googletest lcov make wget cmake
+  brew install llvm@14 googletest lcov make wget cmake snappy
   CLANG_TIDY=/usr/local/bin/clang-tidy
   if [ ! -L "$CLANG_TIDY" ]; then
     $SUDO ln -s $(brew --prefix)/opt/llvm@14/bin/clang-tidy /usr/local/bin/clang-tidy
@@ -39,7 +39,7 @@ fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   apt update
-  apt install -y build-essential wget cmake libgtest-dev lcov git software-properties-common rsync
+  apt install -y build-essential wget cmake libgtest-dev lcov git software-properties-common rsync libsnappy-dev
 
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO apt-key add -
   $SUDO add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"

--- a/src/uhs/atomizer/archiver/CMakeLists.txt
+++ b/src/uhs/atomizer/archiver/CMakeLists.txt
@@ -15,4 +15,5 @@ target_link_libraries(archiverd archiver
                                 ${LEVELDB_LIBRARY}
                                 ${NURAFT_LIBRARY}
                                 secp256k1
-                                ${CMAKE_THREAD_LIBS_INIT})
+                                ${CMAKE_THREAD_LIBS_INIT}
+                                snappy)

--- a/src/uhs/atomizer/atomizer/CMakeLists.txt
+++ b/src/uhs/atomizer/atomizer/CMakeLists.txt
@@ -23,4 +23,5 @@ target_link_libraries(atomizer-raftd atomizer_raft
                                      ${NURAFT_LIBRARY}
                                      ${LEVELDB_LIBRARY}
                                      secp256k1
-                                     ${CMAKE_THREAD_LIBS_INIT})
+                                     ${CMAKE_THREAD_LIBS_INIT}
+                                     snappy)

--- a/src/uhs/atomizer/shard/CMakeLists.txt
+++ b/src/uhs/atomizer/shard/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(shardd shard
                              ${LEVELDB_LIBRARY}
                              ${NURAFT_LIBRARY}
                              secp256k1
-                             ${CMAKE_THREAD_LIBS_INIT})
+                             ${CMAKE_THREAD_LIBS_INIT}
+                             snappy)

--- a/src/uhs/atomizer/watchtower/CMakeLists.txt
+++ b/src/uhs/atomizer/watchtower/CMakeLists.txt
@@ -21,4 +21,5 @@ target_link_libraries(watchtowerd watchtower
                                   crypto
                                   ${NURAFT_LIBRARY}
                                   secp256k1
-                                  ${CMAKE_THREAD_LIBS_INIT})
+                                  ${CMAKE_THREAD_LIBS_INIT}
+                                  snappy)

--- a/src/uhs/twophase/coordinator/CMakeLists.txt
+++ b/src/uhs/twophase/coordinator/CMakeLists.txt
@@ -20,4 +20,5 @@ target_link_libraries(coordinatord coordinator
                                    ${NURAFT_LIBRARY}
                                    ${LEVELDB_LIBRARY}
                                    secp256k1
-                                   ${CMAKE_THREAD_LIBS_INIT})
+                                   ${CMAKE_THREAD_LIBS_INIT}
+                                   snappy)

--- a/src/uhs/twophase/locking_shard/CMakeLists.txt
+++ b/src/uhs/twophase/locking_shard/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(locking-shardd locking_shard
                                      secp256k1
                                      ${NURAFT_LIBRARY}
                                      ${LEVELDB_LIBRARY}
-                                     ${CMAKE_THREAD_LIBS_INIT})
+                                     ${CMAKE_THREAD_LIBS_INIT}
+                                     snappy)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(run_integration_tests ${GTEST_LIBRARY}
                                             secp256k1
                                             ${LEVELDB_LIBRARY}
                                             ${NURAFT_LIBRARY}
-                                            ${CMAKE_THREAD_LIBS_INIT})
+                                            ${CMAKE_THREAD_LIBS_INIT}
+                                            snappy)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(run_unit_tests ${GTEST_LIBRARY}
                                      secp256k1
                                      ${LEVELDB_LIBRARY}
                                      ${NURAFT_LIBRARY}
-                                     ${CMAKE_THREAD_LIBS_INIT})
+                                     ${CMAKE_THREAD_LIBS_INIT}
+                                     snappy)

--- a/tools/shard-seeder/CMakeLists.txt
+++ b/tools/shard-seeder/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_libraries(shard-seeder transaction
                                    crypto
                                    ${LEVELDB_LIBRARY}
                                    ${CMAKE_THREAD_LIBS_INIT}
-                                   secp256k1)
+                                   secp256k1
+                                   snappy)


### PR DESCRIPTION
* Enabled cmake to check for and locate snappy
* Link snappy in everywhere it needs to be
* Ensure snappy is installed by ./scripts/configure.sh

Closes #171; closes #175

Signed-off-by: paparuch <paparuch@0day.im>
Signed-off-by: Sam Stuewe <stuewe@mit.edu>
Co-authored-by: Sam Stuewe <stuewe@mit.edu>