### PR TITLE
Use explicit path to specify snappy library target

### DIFF
--- a/src/uhs/atomizer/archiver/CMakeLists.txt
+++ b/src/uhs/atomizer/archiver/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(archiverd archiver
                                 ${NURAFT_LIBRARY}
                                 secp256k1
                                 ${CMAKE_THREAD_LIBS_INIT}
-                                snappy)
+                                ${SNAPPY_LIBRARY})

--- a/src/uhs/atomizer/atomizer/CMakeLists.txt
+++ b/src/uhs/atomizer/atomizer/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(atomizer-raftd atomizer_raft
                                      ${LEVELDB_LIBRARY}
                                      secp256k1
                                      ${CMAKE_THREAD_LIBS_INIT}
-                                     snappy)
+                                     ${SNAPPY_LIBRARY})

--- a/src/uhs/atomizer/shard/CMakeLists.txt
+++ b/src/uhs/atomizer/shard/CMakeLists.txt
@@ -17,4 +17,4 @@ target_link_libraries(shardd shard
                              ${NURAFT_LIBRARY}
                              secp256k1
                              ${CMAKE_THREAD_LIBS_INIT}
-                             snappy)
+                             ${SNAPPY_LIBRARY})

--- a/src/uhs/atomizer/watchtower/CMakeLists.txt
+++ b/src/uhs/atomizer/watchtower/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(watchtowerd watchtower
                                   ${NURAFT_LIBRARY}
                                   secp256k1
                                   ${CMAKE_THREAD_LIBS_INIT}
-                                  snappy)
+                                  ${SNAPPY_LIBRARY})

--- a/src/uhs/twophase/coordinator/CMakeLists.txt
+++ b/src/uhs/twophase/coordinator/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(coordinatord coordinator
                                    ${LEVELDB_LIBRARY}
                                    secp256k1
                                    ${CMAKE_THREAD_LIBS_INIT}
-                                   snappy)
+                                   ${SNAPPY_LIBRARY})

--- a/src/uhs/twophase/locking_shard/CMakeLists.txt
+++ b/src/uhs/twophase/locking_shard/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(locking-shardd locking_shard
                                      ${NURAFT_LIBRARY}
                                      ${LEVELDB_LIBRARY}
                                      ${CMAKE_THREAD_LIBS_INIT}
-                                     snappy)
+                                     ${SNAPPY_LIBRARY})

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(run_integration_tests ${GTEST_LIBRARY}
                                             ${LEVELDB_LIBRARY}
                                             ${NURAFT_LIBRARY}
                                             ${CMAKE_THREAD_LIBS_INIT}
-                                            snappy)
+                                            ${SNAPPY_LIBRARY})

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -56,4 +56,4 @@ target_link_libraries(run_unit_tests ${GTEST_LIBRARY}
                                      ${LEVELDB_LIBRARY}
                                      ${NURAFT_LIBRARY}
                                      ${CMAKE_THREAD_LIBS_INIT}
-                                     snappy)
+                                     ${SNAPPY_LIBRARY})

--- a/tools/shard-seeder/CMakeLists.txt
+++ b/tools/shard-seeder/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(shard-seeder transaction
                                    ${LEVELDB_LIBRARY}
                                    ${CMAKE_THREAD_LIBS_INIT}
                                    secp256k1
-                                   snappy)
+                                   ${SNAPPY_LIBRARY})


### PR DESCRIPTION
By using the $SNAPPY_LIBRARY env var defined in the base CMakeLists.txt. Note that in macOS the brew snappy library installation path may not be in the LD_LIBRARY_PATH, hence this is required

Signed-off-by: Alexander Jung <104335080+AlexRamRam@users.noreply.github.com>