### PR TITLE
Fix running environment lacks shared libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ RUN mkdir build && \
 # Create 2PC Deployment Image
 FROM $IMAGE_VERSION AS twophase
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libsnappy-dev && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
 # Set working directory
 WORKDIR /opt/tx-processor
 
@@ -56,6 +61,11 @@ COPY --from=builder /opt/tx-processor/2pc-compose.cfg ./2pc-compose.cfg
 
 # Create Atomizer Deployment Image
 FROM $IMAGE_VERSION AS atomizer
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libsnappy-dev && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /opt/tx-processor

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -4,6 +4,7 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DOCKER_IMAGE_TAG_TWOPHASE=${DOCKER_IMAGE_TAG:-opencbdc-tx-twophase}
+DOCKER_IMAGE_TAG_ATOMIZER=${DOCKER_IMAGE_TAG:-opencbdc-tx-atomizer}
 DOCKER_IMAGE_TAG_BASE=${DOCKER_IMAGE_TAG:-opencbdc-tx-base}
 
 # Update submodules before building
@@ -12,3 +13,5 @@ git submodule init && git submodule update
 # Build docker image
 docker build --target base -t $DOCKER_IMAGE_TAG_BASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
 docker build --target twophase --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_TWOPHASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
+docker build --target twophase --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_TWOPHASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
+docker build --target atomizer --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_ATOMIZER -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -13,5 +13,4 @@ git submodule init && git submodule update
 # Build docker image
 docker build --target base -t $DOCKER_IMAGE_TAG_BASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
 docker build --target twophase --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_TWOPHASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
-docker build --target twophase --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_TWOPHASE -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..
 docker build --target atomizer --build-arg BASE_IMAGE=base -t $DOCKER_IMAGE_TAG_ATOMIZER -f $SCRIPT_DIR/../Dockerfile $SCRIPT_DIR/..


### PR DESCRIPTION
Fixed the problem that the docker runtime environment lacks the snappy dynamic link library. Local test has passed.

The runtime docker image size has increased by about 200KB.

See #195