### PR TITLE
Fix eth_getTransactionCount behavior for unknown acccounts

### DIFF
--- a/src/parsec/agent/runners/evm/http_server.cpp
+++ b/src/parsec/agent/runners/evm/http_server.cpp
@@ -384,7 +384,7 @@ namespace cbdc::parsec::agent::rpc {
                 auto& updates = std::get<return_type>(res);
                 auto it = updates.find(runner_params);
 
-                if(it == updates.end()) {
+                if(it == updates.end() || it->second.size() == 0) {
                     // For accounts that don't exist yet, return 1
                     ret["result"] = to_hex_trimmed(evmc::uint256be(1));
                     callback(ret);

--- a/tests/integration/parsec_evm_end_to_end_test.cpp
+++ b/tests/integration/parsec_evm_end_to_end_test.cpp
@@ -697,3 +697,15 @@ TEST_F(parsec_evm_end_to_end_test, erc20_all) {
                            m_acct1_privkey,
                            evmc::uint256be{});
 }
+
+TEST_F(parsec_evm_end_to_end_test, test_new_account_transaction_count) {
+    // Do not re-use this test address within this module:
+    const evmc::address new_test_addr{0xff0000};
+    const auto new_acct_nonce
+        = m_rpc_client->get_transaction_count(new_test_addr);
+
+    // This value to be updated if/when the system default nonce changes to 0:
+    const auto parsec_default_acct_nonce = evmc::uint256be(1);
+
+    ASSERT_EQ(new_acct_nonce, parsec_default_acct_nonce);
+}


### PR DESCRIPTION
Return starting account nonce for unknown accounts instead of error

i.e. In Hardhat, the following should return the starting account nonce:
`await ethers.provider.getTransactionCount(ethers.HDNodeWallet.createRandom().address)`