### PR TITLE
Remove sudo in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ doxygen_generated
 # Default build folder
 build/
 
+# Default dependency installation folder
+prefix/
+
 # 3rd party generated files
 3rdparty/secp256k1_genctx
 3rdparty/src/ecmult_static_context.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 include_directories(3rdparty 3rdparty/secp256k1/include /usr/lib /usr/local/lib /usr/local/include /opt/homebrew/include)
 
+if(DEFINED CMAKE_PREFIX_PATH)
+    include_directories(SYSTEM "${CMAKE_PREFIX_PATH}/include")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-fprofile-arcs -ftest-coverage)
 endif()

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Building..."
 
+# see PREFIX in ./scripts/configure.sh
+PREFIX="$(cd "$(dirname "$0")"/.. && pwd)/prefix"
+
 if [ -z ${BUILD_DIR+x} ]; then
     export BUILD_DIR=build
 fi
@@ -10,14 +13,14 @@ fi
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
-CMAKE_FLAGS=""
+CMAKE_FLAGS=-DCMAKE_PREFIX_PATH="${PREFIX}"
 CPUS=1
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     CPUS=$(grep -c ^processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPUS=$(sysctl -n hw.ncpu)
     XCODE_CMDLINE_DIR=$(xcode-select -p)
-    CMAKE_FLAGS+="-DCMAKE_C_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang -DCMAKE_CXX_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang++ -DCMAKE_CXX_FLAGS=-isystem\ /usr/local/include -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang -DCMAKE_CXX_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang++ -DCMAKE_CXX_FLAGS=-isystem\ /usr/local/include -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
 CMAKE_BUILD_TYPE="Debug"

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -26,28 +26,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   CPUS=$(grep -c ^processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CPUS=$(sysctl -n hw.ncpu)
-  # ensure development environment is set correctly for clang
-  $SUDO xcode-select -switch /Library/Developer/CommandLineTools
-  brew install llvm@14 googletest google-benchmark lcov make wget cmake curl
-  CLANG_TIDY=/usr/local/bin/clang-tidy
-  if [ ! -L "$CLANG_TIDY" ]; then
-    $SUDO ln -s $(brew --prefix)/opt/llvm@14/bin/clang-tidy /usr/local/bin/clang-tidy
-  fi
-  GMAKE=/usr/local/bin/gmake
-  if [ ! -L "$GMAKE" ]; then
-    $SUDO ln -s $(xcode-select -p)/usr/bin/gnumake /usr/local/bin/gmake
-  fi
-fi
-
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  apt update
-  apt install -y build-essential wget cmake libgtest-dev libbenchmark-dev lcov git software-properties-common rsync unzip
-
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO apt-key add -
-  $SUDO add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
-  $SUDO apt install -y clang-format-14 clang-tidy-14
-  $SUDO ln -s -f $(which clang-format-14) /usr/local/bin/clang-format
-  $SUDO ln -s -f $(which clang-tidy-14) /usr/local/bin/clang-tidy
 fi
 
 LEVELDB_VERSION="1.23"
@@ -90,13 +68,6 @@ $SUDO cp libnuraft.a /usr/local/lib
 $SUDO cp -r ../include/libnuraft /usr/local/include
 
 cd ../..
-
-PYTHON_TIDY=/usr/local/bin/run-clang-tidy.py
-if [ ! -f "${PYTHON_TIDY}" ]; then
-  echo -e "${green}Copying run-clang-tidy to /usr/local/bin"
-  wget https://raw.githubusercontent.com/llvm/llvm-project/e837ce2a32369b2e9e8e5d60270c072c7dd63827/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
-  $SUDO mv run-clang-tidy.py /usr/local/bin
-fi
 
 wget https://www.lua.org/ftp/lua-5.4.3.tar.gz
 rm -rf lua-5.4.3

--- a/scripts/install-build-tools.sh
+++ b/scripts/install-build-tools.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "Installing build tools..."
+
+echo "test local pipeline changes"
+
+green="\033[0;32m"
+cyan="\033[0;36m"
+end="\033[0m"
+
+set -e
+
+SUDO=''
+if (( $EUID != 0 )); then
+    echo -e "non-root user, sudo required"
+    SUDO='sudo'
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  CPUS=$(sysctl -n hw.ncpu)
+  # ensure development environment is set correctly for clang
+  $SUDO xcode-select -switch /Library/Developer/CommandLineTools
+  brew install llvm@14 googletest google-benchmark lcov make wget cmake curl
+  CLANG_TIDY=/usr/local/bin/clang-tidy
+  if [ ! -L "$CLANG_TIDY" ]; then
+    $SUDO ln -s $(brew --prefix)/opt/llvm@14/bin/clang-tidy /usr/local/bin/clang-tidy
+  fi
+  GMAKE=/usr/local/bin/gmake
+  if [ ! -L "$GMAKE" ]; then
+    $SUDO ln -s $(xcode-select -p)/usr/bin/gnumake /usr/local/bin/gmake
+  fi
+fi
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  apt update
+  apt install -y build-essential wget cmake libgtest-dev libbenchmark-dev lcov git software-properties-common rsync unzip
+
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO apt-key add -
+  $SUDO add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
+  $SUDO apt install -y clang-format-14 clang-tidy-14
+  $SUDO ln -s -f $(which clang-format-14) /usr/local/bin/clang-format
+  $SUDO ln -s -f $(which clang-tidy-14) /usr/local/bin/clang-tidy
+fi
+
+PYTHON_TIDY=/usr/local/bin/run-clang-tidy.py
+if [ ! -f "${PYTHON_TIDY}" ]; then
+  echo -e "${green}Copying run-clang-tidy to /usr/local/bin"
+  wget https://raw.githubusercontent.com/llvm/llvm-project/e837ce2a32369b2e9e8e5d60270c072c7dd63827/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+  $SUDO mv run-clang-tidy.py /usr/local/bin
+fi


### PR DESCRIPTION
Currently, `./scripts/configure.sh` requires root privileges to build OpenCBDC. These privileges are used for three purposes:
a) installing build environment (e.g. clang, gmake on macOS, etc);
b) installing certain packaged dependencies (e.g. GoogleTest/`libgtest-dev`); and
c) after fetching and compiling sources from the internet, installing certain libraries (e.g. LevelDB, NuRaft, Lua, etc) into OS default install path (usually, `/usr/lib`).

This is suboptimal in multiple ways. First, invocation of sudo is spread all the way through the script, making this dependency harder to audit. Second, installing user-compiled dependencies in `/usr/lib` can interfere with OS package management (e.g., when user has already installed Lua) and makes it harder to develop two OpenCBDC instances side by side, if one of them, for example, wants to bump up its dependencies (e.g. have a never version of evmc).

The two commits below try to amend the above as follows:
- We split out installing build environment (a) and OS packages (b) into a separate script, `./scripts/install-build-tools.sh`. This script requires `sudo`.
- We also adjust `./scripts/configure.sh` to install dependencies in a separate, user-owned prefix directory (currently, this is called `prefix` and lives alongside `build` directory). This makes installation of these dependencies (c) not rely on root privileges and separates them between different instances of OpenCBDC (and system itself).
- We adjust `./scripts/build.sh` and `CMakeLists.txt` to include this prefix directory in dependency search.

If this looks good, I can also produce appropriate changes to the documentation (README.md).