### PR TITLE
Aiming to improve readability of PArSEC (EVM) transaction flow

### DIFF
--- a/src/parsec/agent/impl.hpp
+++ b/src/parsec/agent/impl.hpp
@@ -130,11 +130,11 @@ namespace cbdc::parsec::agent {
         void
         handle_function(const broker::interface::try_lock_return_type& res);
 
-        void handle_run(const runner::interface::run_return_type& res);
+        void handle_run_result(const runner::interface::run_return_type& res);
 
         void handle_commit(broker::interface::commit_return_type res);
 
-        void do_start();
+        void do_start_function();
 
         void do_result();
 

--- a/src/parsec/agent/impl.hpp
+++ b/src/parsec/agent/impl.hpp
@@ -19,10 +19,10 @@ namespace cbdc::parsec::agent {
         enum class state {
             /// Initial state.
             init,
-            /// Begin request sent to broker.
-            begin_sent,
-            /// Begin request failed.
-            begin_failed,
+            /// Request for new ticket number sent to broker.
+            ticket_number_request_sent,
+            /// Request for new ticket number failed.
+            ticket_number_request_failed,
             /// Function bytecode lock sent to broker.
             function_get_sent,
             /// Function bytecode lock request failed.
@@ -124,7 +124,8 @@ namespace cbdc::parsec::agent {
         broker::held_locks_set_type m_requested_locks{};
         bool m_restarted{false};
 
-        void handle_begin(broker::interface::ticketnum_or_errcode_type res);
+        void handle_new_ticket_number(
+            broker::interface::ticketnum_or_errcode_type res);
 
         void
         handle_function(const broker::interface::try_lock_return_type& res);

--- a/src/parsec/agent/runners/evm/http_server.hpp
+++ b/src/parsec/agent/runners/evm/http_server.hpp
@@ -169,12 +169,21 @@ namespace cbdc::parsec::agent::rpc {
                          const server_type::result_callback_type& callback)
             -> bool;
 
+        /** Handles error by invoking parameterized callback function with a
+         * newly created Json::Value instance populated with error code and
+         * message */
         static auto
-        handle_error(const Json::Value& params,
+        handle_error(const server_type::result_callback_type& callback,
+                     int code,
+                     const std::string& message) -> bool;
+        /** Handles error by invoking parameterized callback function with the
+         * parameterized Json::Value instance populated with error code and
+         * message */
+        static auto
+        handle_error(Json::Value& params,
                      const server_type::result_callback_type& callback,
                      int code,
                      const std::string& message) -> bool;
-
         static auto
         handle_number(const Json::Value& params,
                       const server_type::result_callback_type& callback,

--- a/src/parsec/agent/runners/evm/http_server.hpp
+++ b/src/parsec/agent/runners/evm/http_server.hpp
@@ -234,6 +234,13 @@ namespace cbdc::parsec::agent::rpc {
                            const server_type::result_callback_type& callback)
             -> std::optional<bool>;
 
+        auto make_agent(runner::evm_runner_function f_type,
+                        cbdc::buffer& runner_params,
+                        bool is_readonly_run,
+                        size_t id,
+                        const std::function<void(interface::exec_return_type)>&
+                            res_cb_for_agent) -> std::shared_ptr<impl>;
+
         static auto extract_evm_log_query_addresses(
             Json::Value params,
             const server_type::result_callback_type& callback,

--- a/src/parsec/agent/runners/evm/impl.hpp
+++ b/src/parsec/agent/runners/evm/impl.hpp
@@ -89,8 +89,8 @@ namespace cbdc::parsec::agent::runner {
         auto run_get_account_code() -> bool;
         auto run_get_transaction() -> bool;
         auto run_get_transaction_receipt() -> bool;
-        auto run_execute_transaction(const evmc::address& from,
-                                     bool is_readonly_run) -> bool;
+        auto start_execute_transaction(const evmc::address& from,
+                                       bool is_readonly_run) -> bool;
         auto run_get_account() -> bool;
         auto run_get_block() -> bool;
         auto run_get_logs() -> bool;
@@ -107,10 +107,10 @@ namespace cbdc::parsec::agent::runner {
                                  bool is_readonly_run)
             -> std::pair<evmc_message, bool>;
 
-        void handle_lock_from_account(
+        void handle_lockfromaccount_and_continue_exec(
             const broker::interface::try_lock_return_type& res);
 
-        void lock_ticket_number_key();
+        void lock_ticket_number_key_and_continue_exec();
         void lock_index_keys(const std::function<void()>& callback);
         void schedule_exec();
 

--- a/src/parsec/agent/runners/evm/impl.hpp
+++ b/src/parsec/agent/runners/evm/impl.hpp
@@ -111,7 +111,9 @@ namespace cbdc::parsec::agent::runner {
             const broker::interface::try_lock_return_type& res);
 
         void lock_ticket_number_key_and_continue_exec();
-        void lock_index_keys(const std::function<void()>& callback);
+        void
+        lock_index_keys_and_finalize(const std::vector<cbdc::buffer>& keys,
+                                     const std::function<void()>& finalize_fn);
         void schedule_exec();
 
         void schedule(const std::function<void()>& fn);

--- a/src/parsec/broker/impl.cpp
+++ b/src/parsec/broker/impl.cpp
@@ -22,7 +22,9 @@ namespace cbdc::parsec::broker {
           m_directory(std::move(directory)),
           m_log(std::move(logger)) {}
 
-    auto impl::begin(begin_callback_type result_callback) -> bool {
+    auto impl::get_new_ticket_number(
+        std::function<void(ticketnum_or_errcode_type)> result_callback)
+        -> bool {
         if(!m_ticketer->get_ticket_number(
                [this, result_callback](
                    std::optional<parsec::ticket_machine::interface::
@@ -37,7 +39,7 @@ namespace cbdc::parsec::broker {
     }
 
     void impl::handle_ticket_number(
-        begin_callback_type result_callback,
+        std::function<void(ticketnum_or_errcode_type)> result_callback,
         std::optional<
             parsec::ticket_machine::interface::get_ticket_number_return_type>
             res) {

--- a/src/parsec/broker/impl.hpp
+++ b/src/parsec/broker/impl.hpp
@@ -34,7 +34,9 @@ namespace cbdc::parsec::broker {
         /// \param result_callback function to call with the begin result.
         /// \return true if the request to the ticket machine was initiated
         ///         successfully.
-        auto begin(begin_callback_type result_callback) -> bool override;
+        auto get_new_ticket_number(
+            std::function<void(ticketnum_or_errcode_type)> result_callback)
+            -> bool override;
 
         /// Determines the shard responsible for the given key and issues a try
         /// lock request for the key.
@@ -173,7 +175,7 @@ namespace cbdc::parsec::broker {
                              try_lock_return_type& res);
 
         void handle_ticket_number(
-            begin_callback_type result_callback,
+            std::function<void(ticketnum_or_errcode_type)> result_callback,
             std::optional<parsec::ticket_machine::interface::
                               get_ticket_number_return_type> res);
 

--- a/src/parsec/broker/interface.hpp
+++ b/src/parsec/broker/interface.hpp
@@ -83,14 +83,12 @@ namespace cbdc::parsec::broker {
         /// an error code.
         using ticketnum_or_errcode_type
             = std::variant<ticket_number_type, error_code>;
-        /// Callback function type for a begin operation.
-        using begin_callback_type
-            = std::function<void(ticketnum_or_errcode_type)>;
 
         /// Acquires a new ticket number to begin a transaction.
         /// \param result_callback function to call with begin result.
         /// \return true if the operation was initiated successfully.
-        [[nodiscard]] virtual auto begin(begin_callback_type result_callback)
+        [[nodiscard]] virtual auto get_new_ticket_number(
+            std::function<void(ticketnum_or_errcode_type)> result_callback)
             -> bool
             = 0;
 

--- a/src/parsec/util.cpp
+++ b/src/parsec/util.cpp
@@ -195,7 +195,7 @@ namespace cbdc::parsec {
                  broker::key_type key,
                  broker::value_type value,
                  const std::function<void(bool)>& result_callback) -> bool {
-        auto begin_res = broker->begin([=](auto begin_ret) {
+        auto begin_res = broker->get_new_ticket_number([=](auto begin_ret) {
             if(!std::holds_alternative<
                    cbdc::parsec::ticket_machine::ticket_number_type>(
                    begin_ret)) {

--- a/tests/unit/parsec/util.cpp
+++ b/tests/unit/parsec/util.cpp
@@ -11,7 +11,7 @@ namespace cbdc::test {
     void add_to_shard(std::shared_ptr<cbdc::parsec::broker::interface> broker,
                       cbdc::buffer key,
                       cbdc::buffer value) {
-        auto begin_res = broker->begin([&](auto begin_ret) {
+        auto begin_res = broker->get_new_ticket_number([&](auto begin_ret) {
             ASSERT_TRUE(std::holds_alternative<
                         cbdc::parsec::ticket_machine::ticket_number_type>(
                 begin_ret));


### PR DESCRIPTION
Human readability, ease of access and maintainability are subjective to a large degree. An iterative approach of modest-scale changes with potential for discussions and feedback may be the way to go, particularly in a large open source community such as ours.

Here is one iteration of proposed changes from the perspective of following a EVM transaction flow in PArSEC.

Relates to issue #236 (does not solve it)