### PR TITLE
parsec_user_guide.md: slight usability tweaks

### DIFF
--- a/docs/parsec_user_guide.md
+++ b/docs/parsec_user_guide.md
@@ -42,7 +42,6 @@ Go to a new separate directory and run the following:
 
 ```console
 $ mkdir parsec-playground && cd parsec-playground
-$ npm -y init   # `-y` keeps all defaults
 $ npm install @nomicfoundation/hardhat-ethers ethers
 $ npm install hardhat
 ```
@@ -50,7 +49,7 @@ $ npm install hardhat
 Finish with initializing Hardhat using:
 
 ```console
-$ npx hardhat
+$ npx hardhat init
 ```
 
 Select to create a JavaScript project.
@@ -61,7 +60,7 @@ These can all be overwritten for the purpose of this guide.
 However, to use the Hardhat compiler, all Solidity files should be stored in the
 `contracts` subdirectory.
 
-Copy the example [hardhat.config.js](../scripts/hardhat.config.js) into this directory.
+Copy the example [scripts/hardhat.config.js](../scripts/hardhat.config.js) into this directory.
 
 Edit the `url:` value in the `hardhat.config.js` file to correspond with the url of the agent RPC server.
 Using Docker this will be `http://localhost:8080/`.


### PR DESCRIPTION
* `npm -y init` is not necessary, especially as `npm install` lines don't include `--save`
* `npx hardhat` with nothing specified is being deprecated in favor of `npx hardhat init`
* added `scripts/` to make it more clear where `hardhat.config.js` is to be copied from