### PR TITLE
Add CLI arguments to build.sh, specify build type

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
+
 set -e
+
+help() {
+    if [ $# -gt 0 ]; then
+        printf 'Unexpected Argument (%s)\n' "$1"
+    fi
+    printf 'HELP: Usage: %s [Debug|Release|Profiling]\n' "$0"
+    exit 0
+}
+
+# Note:
+# CMAKE_BUILD_TYPE="Debug" adds "-O0 -g" flags by default
+# CMAKE_BUILD_TYPE="Release" adds "-O3 -DNDEBUG" by default
+if [[ "$BUILD_DEBUG" == "1" ]]; then
+    CMAKE_BUILD_TYPE="Debug"
+elif [[ "$BUILD_RELEASE" == "1" ]]; then
+    CMAKE_BUILD_TYPE="Release"
+elif [[ "$BUILD_PROFILING" == "1" ]]; then
+    CMAKE_BUILD_TYPE="Profiling"
+fi
+
+if [ $# -gt 0 ]; then
+    case "$1" in
+        Release|--release|-r) CMAKE_BUILD_TYPE="Release";;
+        Profiling|--profiling|-p) CMAKE_BUILD_TYPE="Profiling";;
+        Debug|--debug|-d) CMAKE_BUILD_TYPE="Debug";;
+        --help|-h) help;;
+        *) help $1;;
+    esac
+fi
 
 echo "Building..."
 
@@ -23,12 +53,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     CMAKE_FLAGS+=" -DCMAKE_C_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang -DCMAKE_CXX_COMPILER=${XCODE_CMDLINE_DIR}/usr/bin/clang++ -DCMAKE_CXX_FLAGS=-isystem\ /usr/local/include -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 fi
 
-CMAKE_BUILD_TYPE="Debug"
-if [[ "$BUILD_RELEASE" == "1" ]]; then
-    CMAKE_BUILD_TYPE="Release"
-elif [[ "$BUILD_PROFILING" == "1" ]]; then
-    CMAKE_BUILD_TYPE="Profiling"
+if [[ -z $CMAKE_BUILD_TYPE ]]; then
+    echo "CMAKE_BUILD_TYPE not set, defaulting to debug"
+    CMAKE_BUILD_TYPE="Debug"
 fi
 
+echo "Building $CMAKE_BUILD_TYPE"
 eval "cmake -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_FLAGS} .."
 make -j$CPUS
+


### PR DESCRIPTION
Adds CLI arguments to build.sh, and prints to stdout the type of build being performed. Default build is still Debug. Additonally supports a BUILD_DEBUG environment variable, and respects previously set values of CMAKE_BUILD_TYPE. 

Low urgency - I found this useful and hopefully others will.