### PR TITLE
Parsec atomic commit fix

### DIFF
--- a/src/parsec/agent/impl.cpp
+++ b/src/parsec/agent/impl.cpp
@@ -435,8 +435,13 @@ namespace cbdc::parsec::agent {
         if(res.has_value()) {
             std::visit(
                 overloaded{
-                    [&](broker::interface::error_code /* e */) {
-                        m_state = state::commit_failed;
+                    [&](broker::interface::error_code e) {
+                        if(e == broker::interface::error_code::commit_hazard) {
+                            // Do not retry
+                            m_state = state::commit_error;
+                        } else {
+                            m_state = state::commit_failed;
+                        }
                         m_log->error("Broker error for commit for",
                                      m_ticket_number.value());
                         m_result = error_code::commit_error;

--- a/src/parsec/agent/runners/lua/server.hpp
+++ b/src/parsec/agent/runners/lua/server.hpp
@@ -6,7 +6,7 @@
 #ifndef OPENCBDC_TX_SRC_PARSEC_AGENT_RUNNERS_LUA_SERVER_H_
 #define OPENCBDC_TX_SRC_PARSEC_AGENT_RUNNERS_LUA_SERVER_H_
 
-#include "agent/server_interface.hpp"
+#include "parsec/agent/server_interface.hpp"
 #include "util/rpc/tcp_server.hpp"
 
 namespace cbdc::parsec::agent::rpc {

--- a/src/parsec/broker/interface.hpp
+++ b/src/parsec/broker/interface.hpp
@@ -76,7 +76,10 @@ namespace cbdc::parsec::broker {
             /// Shard error during finish.
             finish_error,
             /// Shard error during get tickets.
-            get_tickets_error
+            get_tickets_error,
+            /// A commit is attempted without associating update keys with
+            /// ticket
+            commit_hazard
         };
 
         /// Return type from a begin operation. Either a new ticket number or

--- a/src/parsec/util.cpp
+++ b/src/parsec/util.cpp
@@ -5,6 +5,7 @@
 
 #include "util.hpp"
 
+#include <future>
 #include <unordered_map>
 
 namespace cbdc::parsec {
@@ -202,6 +203,7 @@ namespace cbdc::parsec {
                 result_callback(false);
                 return;
             }
+
             auto ticket_number
                 = std::get<cbdc::parsec::ticket_machine::ticket_number_type>(
                     begin_ret);
@@ -243,5 +245,100 @@ namespace cbdc::parsec {
             }
         });
         return begin_res;
+    }
+
+    auto get_row(const std::shared_ptr<broker::interface>& broker,
+                 broker::key_type key,
+                 const std::function<void(
+                     cbdc::parsec::broker::interface::try_lock_return_type)>&
+                     result_callback)
+        -> cbdc::parsec::broker::interface::try_lock_return_type {
+        std::promise<cbdc::parsec::broker::interface::try_lock_return_type>
+            res_promise;
+        auto res_future = res_promise.get_future();
+
+        auto finish_cb = [=](auto finish_ret) {
+            if(finish_ret.has_value()) {
+                result_callback(finish_ret.value());
+            }
+        };
+
+        auto begin_cb = [&](auto begin_ret) {
+            if(!std::holds_alternative<
+                   cbdc::parsec::ticket_machine::ticket_number_type>(
+                   begin_ret)) {
+                res_promise.set_value(
+                    cbdc::parsec::broker::interface::error_code::
+                        ticket_number_assignment);
+                result_callback(cbdc::parsec::broker::interface::error_code::
+                                    ticket_number_assignment);
+                return;
+            }
+
+            auto ticket_number
+                = std::get<cbdc::parsec::ticket_machine::ticket_number_type>(
+                    begin_ret);
+            auto lock_res = broker->try_lock(
+                ticket_number,
+                key,
+                cbdc::parsec::runtime_locking_shard::lock_type::read,
+                [&](auto try_lock_res) {
+                    if(!std::holds_alternative<cbdc::buffer>(try_lock_res)) {
+                        res_promise.set_value(
+                            cbdc::parsec::broker::interface::error_code::
+                                shard_unreachable);
+                        result_callback(cbdc::parsec::broker::interface::
+                                            error_code::shard_unreachable);
+                        return;
+                    }
+                    res_promise.set_value(try_lock_res);
+                    result_callback(try_lock_res);
+
+                    auto commit_cb = [=](auto commit_ret) {
+                        if(commit_ret.has_value()) {
+                            if(std::holds_alternative<
+                                   cbdc::parsec::broker::interface::
+                                       error_code>(commit_ret.value())) {
+                                result_callback(
+                                    std::get<cbdc::parsec::broker::interface::
+                                                 error_code>(
+                                        commit_ret.value()));
+                                return;
+                            }
+                            result_callback(
+                                std::get<cbdc::parsec::runtime_locking_shard::
+                                             shard_error>(commit_ret.value()));
+                            return;
+                        }
+                        auto finish_res
+                            = broker->finish(ticket_number, finish_cb);
+                        if(!finish_res) {
+                            result_callback(cbdc::parsec::broker::interface::
+                                                error_code::finish_error);
+                            return;
+                        }
+                    };
+
+                    auto commit_res = broker->commit(
+                        ticket_number,
+                        runtime_locking_shard::state_update_type(),
+                        commit_cb);
+
+                    if(!commit_res) {
+                        result_callback(cbdc::parsec::broker::interface::
+                                            error_code::commit_error);
+                        return;
+                    }
+                });
+            if(!lock_res) {
+                result_callback(cbdc::parsec::broker::interface::error_code::
+                                    shard_unreachable);
+                return;
+            }
+        };
+        // This never returns false. We don't need the return
+        // value in this context.
+        [[maybe_unused]] auto begin_success = broker->begin(begin_cb);
+        return res_future.get();
     }
 }

--- a/src/parsec/util.hpp
+++ b/src/parsec/util.hpp
@@ -24,7 +24,7 @@ namespace cbdc::parsec {
         /// Transaction semantics defined using Lua.
         lua,
         /// Ethereum-style transactions using EVM.
-        evm,
+        evm
     };
 
     /// Configuration parameters for a phase two system.
@@ -71,6 +71,20 @@ namespace cbdc::parsec {
                  broker::key_type key,
                  broker::value_type value,
                  const std::function<void(bool)>& result_callback) -> bool;
+
+    /// Asynchronously get the value stored at key from the cluster.
+    /// Intended for testing and administrative purposes.
+    /// \param broker broker to use for reading the row.
+    /// \param key key at which to read.
+    /// \param result_callback function to call on fetch success or
+    ///                        failure.
+    /// \return value stored at key
+    auto get_row(const std::shared_ptr<broker::interface>& broker,
+                 broker::key_type key,
+                 const std::function<void(
+                     cbdc::parsec::broker::interface::try_lock_return_type)>&
+                     result_callback)
+        -> cbdc::parsec::broker::interface::try_lock_return_type;
 }
 
 #endif

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(integration)
 
-add_executable(run_integration_tests mock_system.cpp
+add_executable(run_integration_tests smart_contract_atomic_commit_test.cpp
+                                     mock_system.cpp
                                      atomizer_raft_integration_test.cpp
                                      atomizer_end_to_end_test.cpp
                                      gtest_evm_jsonrpc_client.cpp
@@ -31,6 +32,7 @@ target_link_libraries(run_integration_tests ${GTEST_LIBRARY}
                                             coordinator
                                             locking_shard
                                             evm_runner
+                                            lua_runner
                                             ticket_machine
                                             runtime_locking_shard
                                             runners
@@ -49,6 +51,7 @@ target_link_libraries(run_integration_tests ${GTEST_LIBRARY}
                                             ${LEVELDB_LIBRARY}
                                             ${NURAFT_LIBRARY}
                                             ${JSON_LIBRARY}
+                                            ${LUA_LIBRARY}
                                             ${CURL_LIBRARY}
                                             ${MHD_LIBRARY}
                                             ${CMAKE_THREAD_LIBS_INIT})

--- a/tests/integration/correct_state_update.lua
+++ b/tests/integration/correct_state_update.lua
@@ -1,0 +1,32 @@
+function gen_bytecode()
+    pay_contract = function(param)
+        -- take out locks on keys
+        hk1 = "ticketed_key_1"
+        hk2 = "ticketed_key_2"
+        hk3 = "ticketed_key_3"
+        hk4 = "ticketed_key_4"
+        coroutine.yield(hk1)
+        coroutine.yield(hk2)
+        coroutine.yield(hk3)
+        coroutine.yield(hk4)
+
+        updates = {}
+        updates[hk1] = string.pack("c4", "100")
+        updates[hk2] = string.pack("c4", "200")
+        updates[hk3] = string.pack("c4", "250")
+        updates[hk4] = string.pack("c4", "255")
+
+        return updates
+    end
+    c = string.dump(pay_contract, true)
+    tot = ""
+    for i = 1, string.len(c) do
+        hex = string.format("%x", string.byte(c, i))
+        if string.len(hex) < 2 then
+            hex = "0" .. hex
+        end
+        tot = tot .. hex
+    end
+
+    return tot
+end

--- a/tests/integration/data_hazard_contract.lua
+++ b/tests/integration/data_hazard_contract.lua
@@ -1,0 +1,31 @@
+function gen_bytecode()
+    pay_contract = function(param)
+        -- take out locks on keys
+        hk1 = "ticketed_key_1"
+        hk2 = "ticketed_key_2"
+        hk3 = "ticketed_key_3"
+        uhk = "unticketed_key" -- Intentionally don't yield this key
+        coroutine.yield(hk1)
+        coroutine.yield(hk2)
+        coroutine.yield(hk3)
+
+        updates = {}
+        updates[hk1] = string.pack("c4", "100")
+        updates[hk2] = string.pack("c4", "200")
+        updates[hk3] = string.pack("c4", "250")
+        updates[uhk] = string.pack("c4", "255")
+
+        return updates
+    end
+    c = string.dump(pay_contract, true)
+    tot = ""
+    for i = 1, string.len(c) do
+        hex = string.format("%x", string.byte(c, i))
+        if string.len(hex) < 2 then
+            hex = "0" .. hex
+        end
+        tot = tot .. hex
+    end
+
+    return tot
+end

--- a/tests/integration/smart_contract_atomic_commit_test.cpp
+++ b/tests/integration/smart_contract_atomic_commit_test.cpp
@@ -1,0 +1,435 @@
+// Copyright (c) 2024 MIT Digital Currency Initiative,
+//
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "parsec/agent/client.hpp"
+#include "parsec/agent/impl.hpp"
+#include "parsec/agent/runners/lua/impl.hpp"
+#include "parsec/agent/runners/lua/server.hpp"
+#include "parsec/broker/impl.hpp"
+#include "parsec/broker/interface.hpp"
+#include "parsec/directory/impl.hpp"
+#include "parsec/runtime_locking_shard/impl.hpp"
+#include "parsec/ticket_machine/impl.hpp"
+
+#include <future>
+#include <gtest/gtest.h>
+#include <lua.hpp>
+
+class parsec_smart_contract_updates_test : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        const auto server_endpoint
+            = cbdc::network::endpoint_t{"localhost", 8889};
+
+        init_server_and_client(server_endpoint);
+        init_accounts();
+    }
+
+    void init_accounts();
+
+    void
+    init_server_and_client(const cbdc::network::endpoint_t& server_endpoint);
+
+    std::shared_ptr<cbdc::logging::log> m_log{
+        std::make_shared<cbdc::logging::log>(cbdc::logging::log_level::warn)};
+
+    cbdc::parsec::config m_cfg{};
+
+    std::shared_ptr<cbdc::parsec::broker::interface> m_broker;
+    std::vector<
+        std::shared_ptr<cbdc::parsec::runtime_locking_shard::interface>>
+        m_shards;
+    std::shared_ptr<cbdc::parsec::ticket_machine::interface> m_ticket_machine;
+    std::shared_ptr<cbdc::parsec::directory::interface> m_directory;
+
+    std::unique_ptr<cbdc::parsec::agent::rpc::server_interface> m_server;
+    std::vector<std::shared_ptr<cbdc::parsec::agent::rpc::client>> m_agents;
+};
+
+void parsec_smart_contract_updates_test::init_server_and_client(
+    const cbdc::network::endpoint_t& server_endpoint) {
+    m_ticket_machine
+        = std::make_shared<cbdc::parsec::ticket_machine::impl>(m_log, 1);
+    m_directory = std::make_shared<cbdc::parsec::directory::impl>(1);
+    m_shards = std::vector<
+        std::shared_ptr<cbdc::parsec::runtime_locking_shard::interface>>(
+        {std::make_shared<cbdc::parsec::runtime_locking_shard::impl>(m_log)});
+
+    m_broker = std::make_shared<cbdc::parsec::broker::impl>(0,
+                                                            m_shards,
+                                                            m_ticket_machine,
+                                                            m_directory,
+                                                            m_log);
+
+    m_server = std::unique_ptr<cbdc::parsec::agent::rpc::server_interface>();
+    m_server = std::make_unique<cbdc::parsec::agent::rpc::server>(
+        std::make_unique<
+            cbdc::rpc::async_tcp_server<cbdc::parsec::agent::rpc::request,
+                                        cbdc::parsec::agent::rpc::response>>(
+            server_endpoint),
+        m_broker,
+        m_log,
+        m_cfg);
+
+    ASSERT_TRUE(m_server->init());
+    bool running = true;
+    m_agents
+        = std::vector<std::shared_ptr<cbdc::parsec::agent::rpc::client>>();
+
+    auto agent = std::make_shared<cbdc::parsec::agent::rpc::client>(
+        std::vector<cbdc::network::endpoint_t>{server_endpoint});
+    if(!agent->init()) {
+        m_log->error("Error connecting to agent");
+        running = false;
+    } else {
+        m_log->trace("Connected to agent");
+    }
+    m_agents.emplace_back(agent);
+
+    ASSERT_TRUE(running);
+}
+
+void parsec_smart_contract_updates_test::init_accounts() {
+    std::promise<void> complete;
+
+    const auto check_ok_cb = [&complete](bool ok) {
+        ASSERT_TRUE(ok);
+        complete.set_value();
+    };
+
+    auto keys = std::vector<std::string>(0);
+    auto values = std::vector<std::string>(0);
+
+    keys.emplace_back("ticketed_key_1");
+    keys.emplace_back("ticketed_key_2");
+    keys.emplace_back("ticketed_key_3");
+    keys.emplace_back("ticketed_key_4");
+    keys.emplace_back("unticketed_key");
+
+    values.emplace_back("1");
+    values.emplace_back("2");
+    values.emplace_back("3");
+    values.emplace_back("4");
+    values.emplace_back("4");
+
+    const auto* contract_file
+        = "../tests/integration/correct_state_update.lua";
+    lua_State* L = luaL_newstate();
+    luaL_openlibs(L);
+    luaL_dofile(L, contract_file);
+    lua_getglobal(L, "gen_bytecode");
+    if(lua_pcall(L, 0, 2, 0) != 0) {
+        m_log->error("Contract bytecode generation failed, with error:",
+                     lua_tostring(L, -1));
+        return;
+    }
+    auto valid_updates_contract = cbdc::buffer();
+    valid_updates_contract
+        = cbdc::buffer::from_hex(lua_tostring(L, -2)).value();
+    auto valid_updates_key = cbdc::buffer();
+    valid_updates_key.append("valid_updates", 14);
+
+    m_log->trace("Inserting valid contract");
+    auto init_error = std::atomic_bool{false};
+    auto ret
+        = cbdc::parsec::put_row(m_broker,
+                                valid_updates_key,
+                                valid_updates_contract,
+                                [&](bool res) {
+                                    if(!res) {
+                                        init_error = true;
+                                    } else {
+                                        m_log->info("Inserted valid contract");
+                                    }
+                                });
+    if(!ret || init_error) {
+        m_log->error("Error adding valid contract");
+        return;
+    }
+
+    const auto* hazard_contract_file
+        = "../tests/integration/data_hazard_contract.lua";
+    L = luaL_newstate();
+    luaL_openlibs(L);
+    luaL_dofile(L, hazard_contract_file);
+    lua_getglobal(L, "gen_bytecode");
+    if(lua_pcall(L, 0, 2, 0) != 0) {
+        m_log->error("Contract bytecode generation failed, with error:",
+                     lua_tostring(L, -1));
+        return;
+    }
+    auto invalid_updates_contract = cbdc::buffer();
+    invalid_updates_contract
+        = cbdc::buffer::from_hex(lua_tostring(L, -2)).value();
+    auto invalid_updates_key = cbdc::buffer();
+    invalid_updates_key.append("invalid_updates", 16);
+
+    m_log->trace("Inserting invalid contract");
+    init_error = false;
+    ret = cbdc::parsec::put_row(m_broker,
+                                invalid_updates_key,
+                                invalid_updates_contract,
+                                [&](bool res) {
+                                    if(!res) {
+                                        init_error = true;
+                                    } else {
+                                        m_log->info(
+                                            "Inserted invalid contract");
+                                    }
+                                });
+    if(!ret || init_error) {
+        m_log->error("Error adding valid contract");
+        return;
+    }
+
+    for(size_t i = 0; i < keys.size(); i++) {
+        auto key = cbdc::buffer();
+        auto value = cbdc::buffer();
+
+        key.append(keys[i].c_str(), keys[i].length());
+        value.append(values[i].c_str(), values[i].length() + 1);
+
+        cbdc::parsec::put_row(m_broker, key, value, check_ok_cb);
+
+        auto fut = complete.get_future();
+        fut.wait();
+        complete = std::promise<void>();
+        m_log->trace("DONE", i);
+    }
+}
+
+TEST_F(parsec_smart_contract_updates_test, valid_updates) {
+    init_accounts();
+
+    auto valid_key = cbdc::buffer();
+    valid_key.append("valid_updates", 14);
+    auto r = m_agents[0]->exec(
+        valid_key,
+        cbdc::buffer(),
+        false,
+        [&](const cbdc::parsec::agent::interface::exec_return_type& res) {
+            auto success
+                = std::holds_alternative<cbdc::parsec::agent::return_type>(
+                    res);
+            if(success) {
+                m_log->info("Exec succeeded");
+            } else {
+                m_log->warn("Exec failed");
+            }
+        });
+    if(!r) {
+        m_log->error("Unexpected exec error");
+    }
+
+    // Avoid data race
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    auto key = cbdc::buffer();
+    key.append("ticketed_key_1", 14);
+    auto return_value = cbdc::buffer();
+    auto complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    auto fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "100");
+
+    key = cbdc::buffer();
+    key.append("ticketed_key_2", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "200");
+
+    key = cbdc::buffer();
+    key.append("ticketed_key_3", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "250");
+
+    key = cbdc::buffer();
+    key.append("ticketed_key_4", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "255");
+
+    m_log->trace("Complete");
+}
+
+TEST_F(parsec_smart_contract_updates_test, invalid_updates) {
+    init_accounts();
+
+    auto valid_key = cbdc::buffer();
+    valid_key.append("invalid_updates", 16);
+    auto r = m_agents[0]->exec(
+        valid_key,
+        cbdc::buffer(),
+        false,
+        [&](const cbdc::parsec::agent::interface::exec_return_type& res) {
+            auto success
+                = std::holds_alternative<cbdc::parsec::agent::return_type>(
+                    res);
+            if(success) {
+                m_log->info("Exec succeeded");
+            } else {
+                m_log->warn("Exec failed");
+            }
+        });
+    if(!r) {
+        m_log->error("Unexpected exec error");
+    }
+
+    // Avoid data race
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    auto key = cbdc::buffer();
+    key.append("ticketed_key_1", 14);
+    auto return_value = cbdc::buffer();
+    auto complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    auto fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "1");
+
+    key = cbdc::buffer();
+    key.append("ticketed_key_2", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "2");
+
+    key = cbdc::buffer();
+    key.append("ticketed_key_3", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "3");
+
+    key = cbdc::buffer();
+    key.append("unticketed_key", 14);
+    return_value = cbdc::buffer();
+    complete = std::promise<void>();
+    cbdc::parsec::get_row(
+        m_broker,
+        key,
+        [&](cbdc::parsec::broker::interface::try_lock_return_type res) {
+            if(std::holds_alternative<
+                   cbdc::parsec::runtime_locking_shard::value_type>(res)) {
+                auto found = std::get<
+                    cbdc::parsec::runtime_locking_shard::value_type>(res);
+                return_value = found;
+                complete.set_value();
+            } else {
+                m_log->error("get row callback recieved error");
+            }
+        });
+    fut_res = complete.get_future().wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(fut_res, std::future_status::ready);
+    EXPECT_STREQ(return_value.c_str(), "4");
+
+    m_log->trace("Complete");
+}


### PR DESCRIPTION
Fixes a bug which occurs when a smart contract does not request locks on all update keys, resulting in undesirable behavior. 

Aborts a transaction where the agent does not have tickets associated with all update keys. In the case that a contract does not prompt for all update keys to be locked, enforces that the transaction aborts (+ rolls back) and no updates are written, rather than those which are locked. Does not abort if the smart contract correctly requested locks and is still waiting on them, but still rolls back and retries. 