### PR TITLE
Add default platform for Docker builds

### DIFF
--- a/docker-compose-2pc.yml
+++ b/docker-compose-2pc.yml
@@ -7,6 +7,7 @@ services:
       context: .
       target: twophase
     image: opencbdc-tx-twophase
+    platform: linux/amd64
     tty: true
     restart: always
     command: ./build/src/uhs/twophase/sentinel_2pc/sentineld-2pc 2pc-compose.cfg 0
@@ -28,6 +29,7 @@ services:
       context: .
       target: twophase
     image: opencbdc-tx-twophase
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/twophase/coordinator/coordinatord 2pc-compose.cfg 0 0
     expose:
@@ -48,6 +50,7 @@ services:
       context: .
       target: twophase
     image: opencbdc-tx-twophase
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/twophase/locking_shard/locking-shardd 2pc-compose.cfg 0 0
     expose:

--- a/docker-compose-atomizer.yml
+++ b/docker-compose-atomizer.yml
@@ -7,6 +7,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/atomizer/watchtower/watchtowerd atomizer-compose.cfg 0
     ports:
@@ -27,6 +28,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/atomizer/atomizer/atomizer-raftd atomizer-compose.cfg 0
     expose:
@@ -47,6 +49,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/atomizer/archiver/archiverd atomizer-compose.cfg 0
     expose:
@@ -68,6 +71,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/atomizer/shard/shardd atomizer-compose.cfg 0
     expose:
@@ -90,6 +94,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: ./build/src/uhs/atomizer/sentinel/sentineld atomizer-compose.cfg 0
     ports:

--- a/docker-compose-parsec-test.yml
+++ b/docker-compose-parsec-test.yml
@@ -6,7 +6,8 @@ services:
     build:
       context: .
       target: parsec
-    image: opencbdc-tx
+    image: opencbdc-tx-parsec
+    platform: linux/amd64
     tty: true
     command: ./scripts/wait-for-it.sh -s agent0:8080 -t 60 -- ./build/tools/bench/parsec/evm/evm_bench --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loadgen_accounts=8192 --loadgen_txtype=erc20 --telemetry=1
     networks:

--- a/docker-compose-parsec.yml
+++ b/docker-compose-parsec.yml
@@ -7,6 +7,7 @@ services:
       context: .
       target: parsec
     image: opencbdc-tx-parsec
+    platform: linux/amd64
     tty: true
     restart: always
     command: ./scripts/wait-for-it.sh -s ticket0:7777 -t 60 -- ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/agent/agentd --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN --runner_type="evm"
@@ -25,6 +26,7 @@ services:
       context: .
       target: parsec
     image: opencbdc-tx-parsec
+    platform: linux/amd64
     tty: true
     command: ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/ticket_machine/ticket_machined --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
     networks:
@@ -41,6 +43,7 @@ services:
       context: .
       target: parsec
     image: opencbdc-tx-parsec
+    platform: linux/amd64
     tty: true
     command: ./build/src/parsec/runtime_locking_shard/runtime_locking_shardd --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
     networks:

--- a/docker-compose-test-2pc.yml
+++ b/docker-compose-test-2pc.yml
@@ -7,6 +7,7 @@ services:
       context: .
       target: twophase
     image: opencbdc-tx-twophase
+    platform: linux/amd64
     tty: true
     command: sh ./scripts/test-transaction.sh ./2pc-compose.cfg
     networks:

--- a/docker-compose-test-atomizer.yml
+++ b/docker-compose-test-atomizer.yml
@@ -7,6 +7,7 @@ services:
       context: .
       target: atomizer
     image: opencbdc-tx-atomizer
+    platform: linux/amd64
     tty: true
     command: sh ./scripts/test-transaction.sh ./atomizer-compose.cfg
     networks:


### PR DESCRIPTION
Addresses an issue seen with M-series Macs where Docker looks to pull images built for the linux/arm64/v8 platform instead of the linux/amd64 platform by default.

Specifies platform: linux/amd64 in docker-compose files to fix this issue for Mac users.

Minor additional change: also renames the image built / targeted by docker-compose-parsec-test.yml to opencbdc-tx-parsec instead of opencbdc-tx to match convention.