### PR TITLE
fix: update docker base image to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Define image base arg
-ARG IMAGE_VERSION="ubuntu:20.04"
+ARG IMAGE_VERSION="ubuntu:22.04"
 
 # Define base image repo name
 ARG BASE_IMAGE="ghcr.io/mit-dci/opencbdc-tx-base:latest"

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -19,6 +19,8 @@ target_link_libraries(run_benchmarks ${GTEST_LIBRARY}
                                      watchtower
                                      locking_shard
                                      transaction
+                                     rpc
+                                     network
                                      common
                                      serialization
                                      crypto

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 COPY . .
 
 RUN apt update && apt dist-upgrade -y
-RUN ./configure.sh
+RUN ./install-build-tools.sh
+RUN ./setup-dependencies.sh


### PR DESCRIPTION
Having migrated to C++20, we ran into a version of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100346

By migrating to a more recent Ubuntu image, we benefit from more recent compiler versions which avoid the build errors.

The additional library linkages for the benchmarks seem to have become required on some platforms in addition.