### PR TITLE
Publish github pages to external repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,4 +30,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          external_repository: mit-dci/opencbdc-tx-pages
           publish_dir: ./doxygen_generated/html

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,8 +27,8 @@ jobs:
           enable-latex: false
           additional-packages: graphviz
       - name: Deploy GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.TX_PAGES_DEPLOY_KEY }}
           external_repository: mit-dci/opencbdc-tx-pages
           publish_dir: ./doxygen_generated/html


### PR DESCRIPTION
This PR addresses the growing gh-pages branch and re-writes the github pages action to direct pages to an external repository. 
Rather than cloning a single branch to avoid pulling down gh-pages which can be annoying to work with when the repo has multiple branches, having gh-pages in a separate repository may be more useful. 

This also makes gh-pages opt-in instead of opt-out.

PRing this for consideration and discussion, as making this change would require slightly more than merging upstream. 

cc: @madars 
