### PR TITLE
fix: ensure variables are initialized before use

### DIFF
--- a/tools/bench/atomizer-cli-watchtower.cpp
+++ b/tools/bench/atomizer-cli-watchtower.cpp
@@ -367,11 +367,11 @@ auto main(int argc, char** argv) -> int {
     uint32_t batch_counter = 0;
     uint32_t best_height
         = blocking_watchtower_client->request_best_block_height()->height();
-    std::chrono::nanoseconds total_time;
-    std::chrono::nanoseconds check_time;
-    std::chrono::nanoseconds gen_time;
-    std::chrono::nanoseconds add_time;
-    std::chrono::nanoseconds send_time;
+    std::chrono::nanoseconds total_time{};
+    std::chrono::nanoseconds check_time{};
+    std::chrono::nanoseconds gen_time{};
+    std::chrono::nanoseconds add_time{};
+    std::chrono::nanoseconds send_time{};
     uint64_t gen_avg{};
     while(running) {
         static constexpr auto send_amount = 5;


### PR DESCRIPTION
It seems to have flown under the radar, but these lines (should) trigger a warning for use before initialization (due to the use of `+=`).

By default-initializing each of these values, we avoid the warnings (and resultant errors).

Trivial fix.