### PR TITLE
docs: mention new GH-Pages deployment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Note that if you have not already installed the xcode cli tools you will need to
 ```
 # Run the Code
 
+The API Reference is now housed in [an external repository](https://github.com/mit-dci/opencbdc-tx-pages/).
+See the [live deployment](https://mit-dci.github.io/opencbdc-tx-pages/) to browse.
+
 ## UHS-based Architectures (2PC & Atomizer)
 See the [2PC & Atomizer User Guide](docs/2pc_atomizer_user_guide.md)
 ## PArSEC Architecture


### PR DESCRIPTION
Before merging #255, the gh-pages branch of this repository was used for our live API reference instance. Unfortunately, that branch houses multiple binaries which were rebuilt on every-push, leading to the branch growing in-size without bound, and dramatically increasing the storage and network burden for all clones and forks.

Following #255 and the deletion of the gh-pages branch, the repo can be cloned almost instantly, and the burden is fully offloaded to a second repository which no one should need to clone under normal circumstances.

This commit simply adds reference to the new deployment (since GH's web interface is not smart enough to link to the external repo automatically).