### PR TITLE
removed references to the deleted scripts/configure.sh file and made …

### DIFF
--- a/.github/workflows/docker-pull.yml
+++ b/.github/workflows/docker-pull.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           files: |
             Dockerfile
-            **/configure.sh
 
       ########################
       # Build Base           #

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,12 +98,15 @@ $ git push --force origin <your-branch-name>
 Absolutely!
 However, we only officially support the included docker compose files (as they mirror our automated test environment).
 
-After cloning the code, ``scripts/configure.sh`` will attempt to configure your environment.
+After cloning the code, ``scripts/install-build-tools.sh`` needs to be ran just once. It will attempt to install the necessary software tools upon which the project relies on.  
 
-**Note:** ``scripts/configure.sh`` only supports Ubuntu-based linux distributions and macOS (which depends on [Homebrew](https://brew.sh/)).
+Then, ``scripts/setup-dependencies.sh`` should be run to install libraries and dependencies
+to will attempt to configure your environment.
+
+**Note:** ``scripts/install-build-tools.sh`` only supports Ubuntu-based linux distributions and macOS (which depends on [Homebrew](https://brew.sh/)).
 However, it can be used as a guide to understand what you must do to get your environment setup.
 
-In short, ``scripts/configure.sh`` does the following:
+In short, ``scripts/install-build-tools.sh`` does the following:
 
 * installs a couple packages needed for building and testing (e.g., clang, LLVM, cmake, make, lcov, googletest, git)
 * installs the external dependencies:
@@ -127,7 +130,8 @@ However, here are several things you can do to make review as easy and quick as 
 
 * Keep your working branch up-to-date with our main branch and free of merge conflicts
 * Run ``./scripts/lint.sh`` and ``./scripts/test.sh`` and ensure both succeed before committing changes
-    * You can use a tool like [`act`](https://github.com/nektos/act) to run the CI locally and see if your changes would pass automated-review
+* Run ``pylint $(git ls-files '*.py')`` for python code and seek scores close to 10.0. 
+    * You can use a tool like [`act`](https://github.com/nektos/act) to run the CI locally and see if your changes would pass automated-review. ``act --list`` to see workflow jobs.
 * Author [good commits](#what-does-a-good-commit-look-like)
 
 </details>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ fi
 
 echo "Building..."
 
-# see PREFIX in ./scripts/configure.sh
+# see PREFIX in ./scripts/setup-dependencies.sh
 PREFIX="$(cd "$(dirname "$0")"/.. && pwd)/prefix"
 
 if [ -z ${BUILD_DIR+x} ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,7 +29,8 @@ check_format_files=$(git ls-files | grep -E "tools|tests|src|cmake-tests" \
 clang-format --style=file --Werror --dry-run ${check_format_files[@]}
 
 if ! command -v clang-tidy &>/dev/null; then
-  echo "clang-tidy does not appear to be installed. Please run ./scripts/configure.sh to install dependencies or install manually."
+  echo "clang-tidy does not appear to be installed"
+  echo "Please run ./scripts/setup-dependencies.sh to install dependencies or install manually."
   exit 1
 fi
 

--- a/scripts/setup-dependencies.sh
+++ b/scripts/setup-dependencies.sh
@@ -9,8 +9,7 @@ end="\033[0m"
 set -e
 
 # install in a custom prefix rather than /usr/local. by default, this
-# chooses "prefix" directory alongside "scripts" where configure.sh
-# resides.
+# chooses "prefix" directory alongside "scripts" directory.
 
 PREFIX="$(cd "$(dirname "$0")"/.. && pwd)/prefix"
 echo "Will install local dependencies in the following prefix: $PREFIX"


### PR DESCRIPTION
We no longer have `scripts/configure.sh` in the codebase as it has been replaced by `scripts/install-build-tools.sh` and `scripts/setup-dependencies.sh`. 

So removed references to the deprecated `configure.sh` file where it could be confusing to new people onboarding and filled in with the two build scripts we use in its place.