### PR TITLE
updating ubuntu to version 22.04+ in github workflows; fixes #266

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BUILD_RELEASE: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -33,9 +33,9 @@ jobs:
         run: ./scripts/build.sh
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -55,11 +55,11 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Build Env
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -85,7 +85,7 @@ jobs:
       - name: Shorten SHA
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ !env.ACT }}
         name: Archive Test Results
         with:
@@ -98,7 +98,7 @@ jobs:
     name: doxygen
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Doxygen
@@ -109,7 +109,7 @@ jobs:
         run: doxygen Doxyfile
       - name: Upload Docs artifacts
         if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: OpenCBDC Transaction Processor docs for ${{ steps.vars.outputs.sha_short }}
           path: ./doxygen_generated/html/*

--- a/.github/workflows/docker-merge.yml
+++ b/.github/workflows/docker-merge.yml
@@ -5,7 +5,7 @@ name: docker merge
 on:
   push:
     branches:
-      - 'trunk'
+      - trunk
 
 jobs:
   docker-build:
@@ -15,14 +15,14 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ########################
       # Build Base           #
       ########################
       - name: Docker meta base (merge)
         id: meta-base
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -35,20 +35,20 @@ jobs:
             type=sha
 
       - name: Set up QEMU (merge)
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx (merge)
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry (merge)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: base
@@ -69,7 +69,7 @@ jobs:
       ########################
       - name: Docker meta twophase (merge)
         id: meta-twophase
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Docker meta atomizer (merge)
         id: meta-atomizer
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -97,7 +97,7 @@ jobs:
 
       - name: Docker meta parsec (merge)
         id: meta-parsec
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -111,7 +111,7 @@ jobs:
 
 
       - name: Build and push twophase (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: twophase
@@ -122,7 +122,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push atomizer (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: atomizer
@@ -133,7 +133,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push parsec (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: parsec

--- a/.github/workflows/docker-pull.yml
+++ b/.github/workflows/docker-pull.yml
@@ -15,14 +15,14 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: "2"
 
       # For PRs, this action compares between the commit and trunk
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             Dockerfile

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -7,7 +7,7 @@ name: docker push
 on:
   push:
     branches-ignore:
-      - 'trunk'
+      - trunk
 
 jobs:
   docker-build:
@@ -17,7 +17,7 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ########################
       # Build Base           #

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,10 +12,10 @@ defaults:
 jobs:
   gh-pages-deploy:
     name: Github Pages Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/src/parsec/runtime_locking_shard/state_machine.cpp
+++ b/src/parsec/runtime_locking_shard/state_machine.cpp
@@ -83,7 +83,8 @@ namespace cbdc::parsec::runtime_locking_shard {
                 },
                 [&](rpc::replicated_get_tickets_request /* msg */) {
                     return m_shard->get_tickets(
-                        [&](replicated_shard::get_tickets_return_type res) {
+                        [&](const replicated_shard::get_tickets_return_type&
+                                res) {
                             ret = res;
                         });
                 }},


### PR DESCRIPTION
Updated ubuntu 20.04 to 22.04 in github workflows.

Many of the gh actions are deprecated so they need updates for ubuntu 22.04+ to work.

<img width="1639" alt="gh warnings" src="https://github.com/user-attachments/assets/77611b40-5d02-47a5-8816-0d55d9ea4f55">