### PR TITLE
Implement some much-needed improvements for the UHS load-generators

### DIFF
--- a/scripts/get-tx-lifecycle.sh
+++ b/scripts/get-tx-lifecycle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+LOGDIR='.'
+TXID=
+
+IFS='' read -r -d '' usage <<'EOF'
+Usage: %s [options]
+
+Options:
+  -h, --help              print this help and exit
+  -d, --log-dir=PATH      PATH where the log-files are located
+                          (defaults to '.' if not specified)
+  -t, --tx-id=ID          ID of the transaction to trace
+EOF
+
+_help=
+if [[ $# -eq 0 ]]; then
+    _help=1
+fi
+
+_err=0
+while [[ $# -gt 0 ]]; do
+    optarg=
+    shft_cnt=1
+    if [[ "$1" =~ [=] ]]; then
+        optarg="${1#*=}"
+    elif [[ "$1" =~ ^-- && $# -gt 1 && ! "$2" =~ ^- ]]; then
+        optarg="$2"
+        shft_cnt=2
+    elif [[ "$1" =~ ^-[^-] && $# -gt 1 && ! "$2" =~ ^- ]]; then
+        optarg="$2"
+        shft_cnt=2
+    elif [[ "$1" =~ ^-[^-] ]]; then
+        optarg="${1/??/}"
+    fi
+
+    case "$1" in
+        -d*|--log-dir*) LOGDIR="${optarg:-$LOGDIR}"; shift "$shft_cnt";;
+        -t*|--tx-id*)
+            if [[ ! "$optarg" ]]; then
+                printf '`--tx-id` requires an argument\n'
+                _help=1; _err=1;
+                break
+            else
+                TXID="$optarg"
+                shift "$shft_cnt"
+            fi;;
+        -h|--help) _help=1; shift "$shft_cnt";;
+        *)
+            printf 'Unrecognized option: %s\n' "$1"
+            _help=1; _err=1;
+            break;;
+    esac
+done
+
+if [[ -n "$_help" ]]; then
+    printf "$usage" "$(basename $0)"
+    exit "$_err"
+fi
+
+pushd "$LOGDIR" &>/dev/null
+
+all_lines=$(grep -n "$TXID.*at" *.{log,txt})
+sorted_lines=$(printf "%s\n" "$all_lines" | awk -F ' at ' '{ print $2, $0 }' | sort | sed 's/^[^ ]* //')
+
+printf "%s\n" "$sorted_lines"
+
+fst=$(printf "%s\n" "$sorted_lines" | head -n 1)
+lst=$(printf "%s\n" "$sorted_lines" | tail -n 1)
+if [[ $(printf "%s\n" "$fst" | cut -d':' -f1) != $(printf "%s\n" "$lst" | cut -d':' -f1) ]]; then
+    printf 'First and last message for %s are in different logs!\n' "$TXID"
+fi
+
+start=$(printf "%s\n" "$fst" | awk -F ' at ' '{ print $2 }')
+end=$(printf "%s\n" "$lst" | awk -F ' at ' '{ print $2 }')
+
+printf "total elapsed time (assuming all clocks synchronized): %d ticks\n" "$(( end - start ))"
+
+popd &>/dev/null

--- a/scripts/native-system-benchmark.sh
+++ b/scripts/native-system-benchmark.sh
@@ -179,7 +179,7 @@ on_int() {
     printf 'Interrupting all components\n'
     trap '' SIGINT # avoid interrupting ourself
     for i in $PIDS; do # intentionally unquoted
-        if [[ -n "RECORD" ]]; then
+        if [[ -n "$RECORD" ]]; then
             kill -SIGINT -- "-$i"
         else
             kill -SIGINT -- "$i"
@@ -220,7 +220,7 @@ on_int() {
 
     printf 'Terminating any remaining processes\n'
     for i in $PIDS; do # intentionally unquoted
-        if [[ -n "RECORD" ]]; then
+        if [[ -n "$RECORD" ]]; then
             kill -SIGTERM -- "-$i"
         else
             kill -SIGTERM -- "$i"
@@ -350,7 +350,7 @@ launch() {
                         "$RT"/scripts/wait-for-it.sh -q -t 5 -h localhost -p "$ep"
                     done
                     printf 'Launched logical %s %d, replica %d [PID: %d]\n' "$1" "$id" "$node" "$PID"
-                    if [[ -n "RECORD" ]]; then
+                    if [[ -n "$RECORD" ]]; then
                         PIDS="$PIDS $(getpgid $PID)"
                     else
                         PIDS="$PIDS $PID"
@@ -363,7 +363,7 @@ launch() {
                     "$RT"/scripts/wait-for-it.sh -q -t 5 -h localhost -p "$ep"
                 done
                 printf 'Launched %s %d [PID: %d]\n' "$1" "$id" "$PID"
-                if [[ -n "RECORD" ]]; then
+                if [[ -n "$RECORD" ]]; then
                     PIDS="$PIDS $(getpgid $PID)"
                 else
                     PIDS="$PIDS $PID"

--- a/src/uhs/twophase/coordinator/controller.cpp
+++ b/src/uhs/twophase/coordinator/controller.cpp
@@ -689,6 +689,12 @@ namespace cbdc::coordinator {
             return false;
         }
 
+        auto recv_time = std::chrono::high_resolution_clock::now()
+                             .time_since_epoch()
+                             .count();
+        m_logger->trace("Received", to_string(tx.m_id), "at",
+                        recv_time);
+
         if(!transaction::validation::check_attestations(
                tx,
                m_opts.m_sentinel_public_keys,
@@ -719,6 +725,12 @@ namespace cbdc::coordinator {
             m_current_txs->emplace(
                 tx.m_id,
                 std::make_pair(std::move(result_callback), idx));
+
+            auto add_time = std::chrono::high_resolution_clock::now()
+                                .time_since_epoch()
+                                .count();
+            m_logger->trace("Added", to_string(tx.m_id), "to batch at",
+                            add_time);
             return true;
         }();
         if(added) {

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -103,6 +103,11 @@ namespace cbdc::locking_shard {
 
     auto locking_shard::check_and_lock_tx(const tx& t) -> bool {
         bool success{true};
+        auto recv_time = std::chrono::high_resolution_clock::now()
+                             .time_since_epoch()
+                             .count();
+        m_logger->trace("Began check-and-lock of",
+                        to_string(t.m_tx.m_id), "at", recv_time);
         if(!transaction::validation::check_attestations(
                t.m_tx,
                m_opts.m_sentinel_public_keys,
@@ -129,6 +134,11 @@ namespace cbdc::locking_shard {
                 }
             }
         }
+        auto resp_time = std::chrono::high_resolution_clock::now()
+                             .time_since_epoch()
+                             .count();
+        m_logger->trace("Completed check-and-lock of",
+                        to_string(t.m_tx.m_id), "at", resp_time);
         return success;
     }
 

--- a/src/util/common/config.cpp
+++ b/src/util/common/config.cpp
@@ -227,6 +227,13 @@ namespace cbdc::config {
         return ss.str();
     }
 
+    auto get_loadgen_loglevel_key(size_t loadgen_id) -> std::string {
+        std::stringstream ss;
+        ss << loadgen_prefix << loadgen_id << config_separator
+           << loglevel_postfix;
+        return ss.str();
+    }
+
     auto get_sentinel_private_key_key(size_t sentinel_id) -> std::string {
         auto ss = std::stringstream();
         get_sentinel_key_prefix(ss, sentinel_id);
@@ -614,6 +621,23 @@ namespace cbdc::config {
 
         opts.m_loadgen_count
             = cfg.get_ulong(loadgen_count_key).value_or(opts.m_loadgen_count);
+        opts.m_loadgen_tps_target = cfg.get_ulong(tps_target_key)
+                                        .value_or(opts.m_loadgen_tps_target);
+        opts.m_loadgen_tps_step_time
+            = cfg.get_decimal(tps_steptime_key)
+                  .value_or(opts.m_loadgen_tps_step_time);
+        opts.m_loadgen_tps_step_size
+            = cfg.get_decimal(tps_stepsize_key)
+                  .value_or(opts.m_loadgen_tps_step_size);
+        opts.m_loadgen_tps_initial = cfg.get_decimal(tps_initial_key)
+                                         .value_or(opts.m_loadgen_tps_initial);
+        for(size_t i{0}; i < opts.m_loadgen_count; ++i) {
+            const auto loadgen_loglevel_key = get_loadgen_loglevel_key(i);
+            const auto loadgen_loglevel
+                = cfg.get_loglevel(loadgen_loglevel_key)
+                      .value_or(defaults::log_level);
+            opts.m_loadgen_loglevels.push_back(loadgen_loglevel);
+        }
     }
 
     auto read_options(const std::string& config_file)

--- a/src/util/common/config.hpp
+++ b/src/util/common/config.hpp
@@ -100,6 +100,11 @@ namespace cbdc::config {
     static constexpr auto output_count_key = "loadgen_sendtx_output_count";
     static constexpr auto invalid_rate_key = "loadgen_invalid_tx_rate";
     static constexpr auto fixed_tx_rate_key = "loadgen_fixed_tx_rate";
+    static constexpr auto loadgen_prefix = "loadgen";
+    static constexpr auto tps_target_key = "loadgen_tps_target";
+    static constexpr auto tps_steptime_key = "loadgen_tps_step_time";
+    static constexpr auto tps_stepsize_key = "loadgen_tps_step_percentage";
+    static constexpr auto tps_initial_key = "loadgen_tps_step_start";
     static constexpr auto archiver_count_key = "archiver_count";
     static constexpr auto watchtower_count_key = "watchtower_count";
     static constexpr auto watchtower_prefix = "watchtower";
@@ -249,6 +254,18 @@ namespace cbdc::config {
 
         /// Number of load generators over which to split pre-seeded UTXOs.
         size_t m_loadgen_count{0};
+
+        /// List of loadgen log levels, ordered by loadgen ID.
+        std::vector<logging::log_level> m_loadgen_loglevels;
+
+        /// Maximum Tx/s the loadgens should produce
+        size_t m_loadgen_tps_target{0};
+        /// Percent of target to send at test-start
+        double m_loadgen_tps_initial{0};
+        /// Percent (of target-initial) to increase on each step
+        double m_loadgen_tps_step_size{0};
+        /// Time (fractional seconds) to wait before the next step up
+        double m_loadgen_tps_step_time{0};
 
         /// Private keys for sentinels.
         std::unordered_map<size_t, privkey_t> m_sentinel_private_keys;

--- a/tools/bench/twophase_gen.cpp
+++ b/tools/bench/twophase_gen.cpp
@@ -34,8 +34,14 @@ auto main(int argc, char** argv) -> int {
     auto cfg = std::get<cbdc::config::options>(cfg_or_err);
 
     auto gen_id = std::stoull(args[2]);
-    auto logger
-        = std::make_shared<cbdc::logging::log>(cbdc::logging::log_level::info);
+    if(gen_id >= cfg.m_loadgen_count) {
+        std::cerr << "Attempted to run more loadgens than configured"
+                  << std::endl;
+        return -1;
+    }
+
+    auto logger = std::make_shared<cbdc::logging::log>(
+        cfg.m_loadgen_loglevels[gen_id]);
 
     auto sha2_impl = SHA256AutoDetect();
     logger->info("using sha2: ", sha2_impl);
@@ -115,6 +121,26 @@ auto main(int argc, char** argv) -> int {
         logger->info("Mint confirmed");
     }
 
+    size_t per_gen_send_limit = 0;
+    size_t per_gen_step_size = 0;
+    if(cfg.m_loadgen_tps_target != 0) {
+        per_gen_send_limit = static_cast<size_t>(
+            cfg.m_loadgen_tps_initial
+            * static_cast<double>(cfg.m_loadgen_tps_target));
+        double per_gen_range = static_cast<double>(cfg.m_loadgen_tps_target)
+                             - static_cast<double>(per_gen_send_limit);
+        // clamp step (s) such that 1 <= s <= (target - initial)
+        per_gen_step_size = std::max(
+            std::min(static_cast<size_t>(per_gen_range
+                                         * cfg.m_loadgen_tps_step_size),
+                     static_cast<size_t>(per_gen_range)),
+            size_t{1});
+    }
+
+    if(cfg.m_loadgen_tps_step_time == 0) {
+        per_gen_send_limit = cfg.m_loadgen_tps_target;
+    }
+
     static constexpr auto lookup_timeout = std::chrono::milliseconds(5000);
     auto status_client = cbdc::locking_shard::rpc::status_client(
         cfg.m_locking_shard_readonly_endpoints,
@@ -161,7 +187,17 @@ auto main(int argc, char** argv) -> int {
 
     constexpr auto send_amt = 5;
 
+    uint64_t send_gap{};
     uint64_t gen_avg{};
+    auto ramp_secs = std::chrono::duration<double, std::ratio<1, 1>>(
+        cfg.m_loadgen_tps_step_time);
+    auto ramp_timer_full
+        = std::chrono::duration_cast<std::chrono::nanoseconds>(ramp_secs);
+
+    auto ramp_timer = ramp_timer_full;
+    auto ramping = ramp_timer.count() != 0
+                && per_gen_send_limit != cfg.m_loadgen_tps_target
+                && cfg.m_loadgen_tps_target != 0;
     auto gen_thread = std::thread([&]() {
         while(running) {
             // Determine if we should attempt to send a double-spending
@@ -219,8 +255,52 @@ auto main(int argc, char** argv) -> int {
                 gen_avg = static_cast<uint64_t>(
                     (static_cast<double>(gen_t.count()) * average_factor)
                     + (static_cast<double>(gen_avg) * (1.0 - average_factor)));
+                if(ramping) {
+                    if(gen_t >= ramp_timer) {
+                        logger->debug(
+                            "Ramp Timer Exhausted (gen_t). Resetting");
+                        ramp_timer = ramp_timer_full;
+                        per_gen_send_limit
+                            = std::min(cfg.m_loadgen_tps_target,
+                                       per_gen_send_limit + per_gen_step_size);
+                        logger->debug("New Send Limit:", per_gen_send_limit);
+                        if(per_gen_send_limit == cfg.m_loadgen_tps_target) {
+                            ramping = false;
+                            logger->info("Reached Target Throughput");
+                        }
+                    } else {
+                        ramp_timer -= gen_t;
+                    }
+                    auto total_send_time
+                        = std::chrono::nanoseconds(gen_avg * per_gen_send_limit);
+                    if(total_send_time < std::chrono::seconds(1)
+                        && per_gen_send_limit != 0) {
+                        send_gap
+                            = (std::chrono::seconds(1) - total_send_time).count()
+                            / per_gen_send_limit;
+                        logger->trace("New send-gap:", send_gap);
+                    }
+                }
             } else {
                 std::this_thread::sleep_for(std::chrono::nanoseconds(gen_avg));
+                if(ramping) {
+                    auto avg = std::chrono::nanoseconds(gen_avg);
+                    if(avg >= ramp_timer) {
+                        logger->debug("Ramp Timer Exhausted (dbl-spend "
+                                      "gen_avg). Resetting");
+                        ramp_timer = ramp_timer_full;
+                        per_gen_send_limit
+                            = std::min(cfg.m_loadgen_tps_target,
+                                       per_gen_send_limit + per_gen_step_size);
+                        logger->debug("New Send Limit:", per_gen_send_limit);
+                        if(per_gen_send_limit == cfg.m_loadgen_tps_target) {
+                            ramping = false;
+                            logger->info("Reached Target Throughput");
+                        }
+                    } else {
+                        ramp_timer -= avg;
+                    }
+                }
             }
 
             // We couldn't send a double-spend or a newly generated valid
@@ -234,6 +314,23 @@ auto main(int argc, char** argv) -> int {
                 // instead.
                 static constexpr auto send_delay = std::chrono::seconds(1);
                 std::this_thread::sleep_for(send_delay);
+                if(ramping) {
+                    if(send_delay >= ramp_timer) {
+                        logger->debug(
+                            "Ramp Timer Exhausted (send_delay). Resetting");
+                        ramp_timer = ramp_timer_full;
+                        per_gen_send_limit
+                            = std::min(cfg.m_loadgen_tps_target,
+                                       per_gen_send_limit + per_gen_step_size);
+                        logger->debug("New Send Limit:", per_gen_send_limit);
+                        if(per_gen_send_limit == cfg.m_loadgen_tps_target) {
+                            ramping = false;
+                            logger->info("Reached Target Throughput");
+                        }
+                    } else {
+                        ramp_timer -= send_delay;
+                    }
+                }
                 continue;
             }
 
@@ -279,6 +376,27 @@ auto main(int argc, char** argv) -> int {
                                                     std::move(res_cb))) {
                 logger->error("Failure sending transaction to sentinel");
                 wallet.confirm_inputs(tx.value().m_inputs);
+            }
+
+            auto gap = std::chrono::nanoseconds(send_gap);
+            if(gap < std::chrono::seconds(1)) {
+                std::this_thread::sleep_for(gap);
+                if(ramping) {
+                    if(gap >= ramp_timer) {
+                        logger->debug("Ramp Timer Exhausted (gap). Resetting");
+                        ramp_timer = ramp_timer_full;
+                        per_gen_send_limit
+                            = std::min(cfg.m_loadgen_tps_target,
+                                       per_gen_send_limit + per_gen_step_size);
+                        logger->debug("New Send Limit:", per_gen_send_limit);
+                        if(per_gen_send_limit == cfg.m_loadgen_tps_target) {
+                            ramping = false;
+                            logger->info("Reached Target Throughput");
+                        }
+                    } else {
+                        ramp_timer -= gap;
+                    }
+                }
             }
         }
     });


### PR DESCRIPTION
This first commit brings targeted-load for the 2PC load-gen; another commit will follow updating the atomizer load-gen as well.

cf. #279 

I've been locally testing using variants of the configuration below:

<details>
<summary>Configuration</summary>

```
shard0_count=1
shard0_start=0
shard0_end=255
shard0_0_endpoint="0.0.0.0:5002"
shard0_0_raft_endpoint="0.0.0.0:5003"
shard0_0_readonly_endpoint="0.0.0.0:5004"
shard0_audit_log="shard0_audit_log"
shard1_count=1
shard1_start=128
shard1_end=255
shard1_0_endpoint="0.0.0.0:5005"
shard1_0_raft_endpoint="0.0.0.0:5006"
shard1_0_readonly_endpoint="0.0.0.0:5007"
shard1_audit_log="shard1_audit_log"
coordinator0_count=1
coordinator0_0_endpoint="0.0.0.0:6001"
coordinator0_0_raft_endpoint="0.0.0.0:6002"
coordinator1_count=1
coordinator1_0_endpoint="0.0.0.0:6003"
coordinator1_0_raft_endpoint="0.0.0.0:6004"
sentinel0_endpoint="0.0.0.0:7003"
sentinel1_endpoint="0.0.0.0:8003"
sentinel2_endpoint="0.0.0.0:9003"
sentinel3_endpoint="0.0.0.0:9004"
coordinator0_loglevel="TRACE"
coordinator1_loglevel="TRACE"
sentinel0_loglevel="TRACE"
sentinel1_loglevel="TRACE"
sentinel2_loglevel="TRACE"
sentinel3_loglevel="TRACE"
shard0_loglevel="WARN"
shard1_loglevel="TRACE"
twophase-gen0_loglevel="TRACE"
loadgen0_loglevel="DEBUG"
stxo_cache_depth=0
window_size=100000
batch_size=3000
watchtower_block_cache_size=100
watchtower_error_cache_size=10000000
audit_interval=900
attestation_threshold=2
target_block_interval=250
election_timeout_upper=1000
election_timeout_lower=500
heartbeat=250
raft_max_batch=100000
snapshot_distance=0
batch_delay=1

seed_privkey="a0f36553548b3a66c003413140d7b59e43464ca11af66f25a6e746be501596b7"
seed_value=10
seed_from=0
seed_to=10000

loadgen_sendtx_input_count=2
loadgen_sendtx_output_count=2
loadgen_invalid_tx_rate=0.000000
loadgen_fixed_tx_rate=0.07
loadgen_tps_target=850
loadgen_tps_step_time=3.0
loadgen_tps_step_percentage=0.05
loadgen_tps_step_start=0.2

shard_count=1
coordinator_count=2
loadgen_count=1
sentinel_count=2

2pc=1
sentinel0_private_key="1ffed20f548336af31ddc58fb8db7ef6195b91d1851021cf9fc3b8b196f58fc0"
sentinel0_public_key="6e4fae7a0c180ff20f54698136e4585bf7be045cd5ad621f5c8881871e29c024"
sentinel1_private_key="a94d4bfed8d8679a97f74964c2e19b07098d291ae4967f8f0417821c18253b0e"
sentinel1_public_key="3f8f5f79191ef88d25ede8453f09cb8e1ae5b7b1d98aece1cb25e9d047eca505"
sentinel2_private_key="1ffed20f548336af31ddc58fb8db7ef6195b91d1851021cf9fc3b8b196f58fc0"
sentinel2_public_key="6e4fae7a0c180ff20f54698136e4585bf7be045cd5ad621f5c8881871e29c024"
sentinel3_private_key="a94d4bfed8d8679a97f74964c2e19b07098d291ae4967f8f0417821c18253b0e"
sentinel3_public_key="3f8f5f79191ef88d25ede8453f09cb8e1ae5b7b1d98aece1cb25e9d047eca505"
```

</details>