### PR TITLE
lua code improvements

### DIFF
--- a/scripts/gen_bytecode.lua
+++ b/scripts/gen_bytecode.lua
@@ -3,18 +3,14 @@ function gen_bytecode()
         from, to, value, sequence, sig = string.unpack("c32 c32 I8 I8 c64", param)
 
         function get_account_key(name)
-            account_prefix = "account_"
-            account_key = account_prefix .. name
-            return account_key
+            return "account_" .. name
         end
 
         function get_account(name)
             account_key = get_account_key(name)
             account_data = coroutine.yield(account_key)
-            if string.len(account_data) > 0 then
-                account_balance, account_sequence
-                = string.unpack("I8 I8", account_data)
-                return account_balance, account_sequence
+            if #account_data > 0 then
+                return string.unpack("I8 I8", account_data)
             end
             return 0, 0
         end
@@ -59,14 +55,10 @@ function gen_bytecode()
         return update_accounts(from, from_balance, from_seq, to, to_balance, to_seq)
     end
     c = string.dump(pay_contract, true)
-    tot = ""
-    for i = 1, string.len(c) do
-        hex = string.format("%x", string.byte(c, i))
-        if string.len(hex) < 2 then
-            hex = "0" .. hex
-        end
-        tot = tot .. hex
+    t = {}
+    for i = 1, #c do
+        t[#t + 1] = string.format("%02x", string.byte(c, i))
     end
 
-    return tot
+    return table.concat(t)
 end

--- a/tests/integration/correct_state_update.lua
+++ b/tests/integration/correct_state_update.lua
@@ -19,14 +19,10 @@ function gen_bytecode()
         return updates
     end
     c = string.dump(pay_contract, true)
-    tot = ""
-    for i = 1, string.len(c) do
-        hex = string.format("%x", string.byte(c, i))
-        if string.len(hex) < 2 then
-            hex = "0" .. hex
-        end
-        tot = tot .. hex
+    t = {}
+    for i = 1, #c do
+        t[#t + 1] = string.format("%02x", string.byte(c, i))
     end
 
-    return tot
+    return table.concat(t)
 end

--- a/tests/integration/data_hazard_contract.lua
+++ b/tests/integration/data_hazard_contract.lua
@@ -18,14 +18,10 @@ function gen_bytecode()
         return updates
     end
     c = string.dump(pay_contract, true)
-    tot = ""
-    for i = 1, string.len(c) do
-        hex = string.format("%x", string.byte(c, i))
-        if string.len(hex) < 2 then
-            hex = "0" .. hex
-        end
-        tot = tot .. hex
+    t = {}
+    for i = 1, #c do
+        t[#t + 1] = string.format("%02x", string.byte(c, i))
     end
 
-    return tot
+    return table.concat(t)
 end

--- a/tests/unit/parsec/agent/runners/lua/gen_pay_contract.lua
+++ b/tests/unit/parsec/agent/runners/lua/gen_pay_contract.lua
@@ -3,18 +3,14 @@ function gen_bytecode()
         from, to, value, sequence, sig = string.unpack("c32 c32 I8 I8 c64", param)
 
         function get_account_key(name)
-            account_prefix = "account_"
-            account_key = account_prefix .. name
-            return account_key
+            return "account_" .. name
         end
 
         function get_account(name)
             account_key = get_account_key(name)
             account_data = coroutine.yield(account_key)
-            if string.len(account_data) > 0 then
-                account_balance, account_sequence
-                = string.unpack("I8 I8", account_data)
-                return account_balance, account_sequence
+            if #account_data > 0 then
+                return string.unpack("I8 I8", account_data)
             end
             return 0, 0
         end
@@ -59,14 +55,10 @@ function gen_bytecode()
         return update_accounts(from, from_balance, from_seq, to, to_balance, to_seq)
     end
     c = string.dump(pay_contract, true)
-    tot = ""
-    for i = 1, string.len(c) do
-        hex = string.format("%x", string.byte(c, i))
-        if string.len(hex) < 2 then
-            hex = "0" .. hex
-        end
-        tot = tot .. hex
+    t = {}
+    for i = 1, #c do
+        t[#t + 1] = string.format("%02x", string.byte(c, i))
     end
 
-    return tot
+    return table.concat(t)
 end


### PR DESCRIPTION
This PR makes various improvements to the `gen_bytecode.lua` code:

- removes extra variables
- replaces function calls to string length with operator # (much faster)
- replaces for loop string concatenation with lua "string buffer" idiom 
- replaces conditional with two digit, left-padding format specifier