### PR TITLE
ci: get docker merge passing; fixes #283

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ charts/
 # Prevent copying scripts that are unused in docker
 scripts/
 !scripts/test.sh
+!scripts/activate-venv.sh
 !scripts/install-build-tools.sh
 !scripts/setup-dependencies.sh
 !scripts/test-transaction.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ ARG BASE_IMAGE="ghcr.io/mit-dci/opencbdc-tx-base:latest"
 FROM $IMAGE_VERSION AS base
 
 # set non-interactive shell
-ENV DEBIAN_FRONTEND noninteractive
-ENV CMAKE_BUILD_TYPE Release
-ENV BUILD_RELEASE 1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CMAKE_BUILD_TYPE=Release
+ENV BUILD_RELEASE=1
 
 RUN mkdir -p /opt/tx-processor/scripts
 
+COPY requirements.txt /opt/tx-processor/requirements.txt
+COPY scripts/activate-venv.sh /opt/tx-processor/scripts/activate-venv.sh
 COPY scripts/install-build-tools.sh /opt/tx-processor/scripts/install-build-tools.sh
 COPY scripts/setup-dependencies.sh /opt/tx-processor/scripts/setup-dependencies.sh
 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -1,5 +1,5 @@
+#!/usr/bin/env bash
 
-#!/bin/bash
 set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/scripts/install-build-tools.sh
+++ b/scripts/install-build-tools.sh
@@ -51,7 +51,8 @@ create_venv_install_python() {
         if rm -rf -- "${ENV_LOCATION}"; then
             echo "Removed existing virtual environment"
         else
-            echo "Failed to remove existing virtual environment"; exit 1
+            echo "Failed to remove existing virtual environment"
+            exit 1
         fi
     fi
     # install pip for linux
@@ -82,10 +83,14 @@ create_venv_install_python() {
     if "${PY_LOC}" -m venv "${ENV_NAME}"; then
         echo "Virtual environment '${ENV_NAME}' created"
     else
-        echo "Virtual environment creation failed"; exit 1
+        echo "Virtual environment creation failed"
+        exit 1
     fi
     # activate virtual environment
-    source "${ROOT}/scripts/activate-venv.sh"
+    if ! . "${ROOT}/scripts/activate-venv.sh"; then
+        echo "Failed to activate virtual environment"
+        exit 1
+    fi
     # install python packages
     if pip install -r "${ROOT}/requirements.txt"; then
         echo "Success installing python packages"


### PR DESCRIPTION
> Changed docker merge stage to run on pull-request in addition to merge to see if it will pass or fail before a merge takes place. `.github/workflows/docker-push.yml`
Although it is for testing, it might be valuable to keep this to avoid future issues

> Edited the`.dockerignore` and `Dockerfile` so that `scripts/activate-venv.sh` is found
Error:
```console
...
251.1 scripts/install-build-tools.sh: line 87: /scripts/activate-venv.sh: No such file or directory
-----------------------------------
Dockerfile:23
-----------------------------------
21 |      WORKDIR /opt/tx-processor
22 | 
23 |  >>> RUN scripts/install-build-tools.sh
24 |      RUN scripts/setup-dependencies.sh
----------------------------------
ERROR: failed to solve: process "/bin/sh -c scripts/install-build-tools.sh" did not complete successfully: exit code: 1
...
```

> Added '.' to `scripts/install-build-tools.sh` sourcing the venv instead of 'source' due to Michael's point about sh not being able to run source.
