### PR TITLE
fix: include the prefix directory in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ run
 plots
 .vscode
 .deps
+prefix
 
 # E2E test results
 testruns


### PR DESCRIPTION
Noticed on macOS that ./scripts/build-docker.sh was failing. Our Dockerfile runs ./scripts/setup-dependencies.sh in the container before running `COPY . .`, which if prefix/ is not ignored, will copy in the libraries built on the host.