### PR TITLE
clang format script added to auto-format C++ code; fixes #293

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Usage: ./scripts/clang-format.sh
+echo "Running clang format..."
+
+check_format_files=$(git ls-files | grep -E "tools|tests|src|cmake-tests" \
+                     | grep -E "\..*pp")
+clang-format -i --style=file ${check_format_files[@]}
+
+echo "Done."

--- a/src/parsec/agent/client.cpp
+++ b/src/parsec/agent/client.cpp
@@ -11,7 +11,7 @@
 namespace cbdc::parsec::agent::rpc {
     client::client(std::vector<network::endpoint_t> endpoints)
         : m_client(std::make_unique<decltype(m_client)::element_type>(
-            std::move(endpoints))) {}
+              std::move(endpoints))) {}
 
     auto client::init() -> bool {
         return m_client->init();

--- a/src/parsec/agent/client.hpp
+++ b/src/parsec/agent/client.hpp
@@ -36,11 +36,11 @@ namespace cbdc::parsec::agent::rpc {
         /// \param is_readonly_run true if agent should skip writing any state changes.
         /// \param result_callback function to call with execution result.
         /// \return true if the request was sent successfully.
-        auto exec(runtime_locking_shard::key_type function,
-                  parameter_type param,
-                  bool is_readonly_run,
-                  const interface::exec_callback_type& result_callback)
-            -> bool;
+        auto
+        exec(runtime_locking_shard::key_type function,
+             parameter_type param,
+             bool is_readonly_run,
+             const interface::exec_callback_type& result_callback) -> bool;
 
       private:
         std::unique_ptr<cbdc::rpc::tcp_client<request, response>> m_client;

--- a/src/parsec/agent/format.cpp
+++ b/src/parsec/agent/format.cpp
@@ -8,13 +8,13 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser, const parsec::agent::rpc::request& req)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const parsec::agent::rpc::request& req) -> serializer& {
         return ser << req.m_function << req.m_param << req.m_is_readonly_run;
     }
 
-    auto operator>>(serializer& deser, parsec::agent::rpc::request& req)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::rpc::request& req) -> serializer& {
         return deser >> req.m_function >> req.m_param >> req.m_is_readonly_run;
     }
 }

--- a/src/parsec/agent/format.hpp
+++ b/src/parsec/agent/format.hpp
@@ -10,10 +10,10 @@
 #include "util/serialization/serializer.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser, const parsec::agent::rpc::request& req)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::rpc::request& req)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const parsec::agent::rpc::request& req) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::rpc::request& req) -> serializer&;
 }
 
 #endif

--- a/src/parsec/agent/impl.cpp
+++ b/src/parsec/agent/impl.cpp
@@ -188,11 +188,10 @@ namespace cbdc::parsec::agent {
         res_cb(std::move(res));
     }
 
-    auto
-    impl::do_try_lock_request(broker::key_type key,
-                              broker::lock_type locktype,
-                              broker::interface::try_lock_callback_type res_cb)
-        -> bool {
+    auto impl::do_try_lock_request(
+        broker::key_type key,
+        broker::lock_type locktype,
+        broker::interface::try_lock_callback_type res_cb) -> bool {
         // TODO: permissions for keys
         std::unique_lock l(m_mut);
         assert(m_ticket_number.has_value());

--- a/src/parsec/agent/impl.hpp
+++ b/src/parsec/agent/impl.hpp
@@ -147,11 +147,10 @@ namespace cbdc::parsec::agent {
 
         /// Request the broker to attempt to lock the parameterized key
         /// \return true is returned unless the system is in an unexpected state
-        [[nodiscard]] auto
-        do_try_lock_request(broker::key_type key,
-                            broker::lock_type locktype,
-                            broker::interface::try_lock_callback_type res_cb)
-            -> bool;
+        [[nodiscard]] auto do_try_lock_request(
+            broker::key_type key,
+            broker::lock_type locktype,
+            broker::interface::try_lock_callback_type res_cb) -> bool;
 
         void
         handle_rollback(broker::interface::rollback_return_type rollback_res);

--- a/src/parsec/agent/interface.hpp
+++ b/src/parsec/agent/interface.hpp
@@ -66,8 +66,8 @@ namespace cbdc::parsec::agent {
 
         /// Return the key of the function bytecode managed by this agent.
         /// \return function bytecode key.
-        [[nodiscard]] auto get_function() const
-            -> runtime_locking_shard::key_type;
+        [[nodiscard]] auto
+        get_function() const -> runtime_locking_shard::key_type;
 
         /// Return the function parameter managed by this agent.
         /// \return function parameter.

--- a/src/parsec/agent/runners/evm/address.cpp
+++ b/src/parsec/agent/runners/evm/address.cpp
@@ -30,10 +30,10 @@ namespace cbdc::parsec::agent::runner {
         return new_addr;
     }
 
-    auto contract_address2(const evmc::address& sender,
-                           const evmc::bytes32& salt,
-                           const cbdc::hash_t& bytecode_hash)
-        -> evmc::address {
+    auto
+    contract_address2(const evmc::address& sender,
+                      const evmc::bytes32& salt,
+                      const cbdc::hash_t& bytecode_hash) -> evmc::address {
         // Specs: https://eips.ethereum.org/EIPS/eip-1014
 
         auto new_addr = evmc::address();
@@ -53,9 +53,9 @@ namespace cbdc::parsec::agent::runner {
         return new_addr;
     }
 
-    auto eth_addr(const std::unique_ptr<secp256k1_pubkey>& pk,
-                  const std::shared_ptr<secp256k1_context>& ctx)
-        -> evmc::address {
+    auto
+    eth_addr(const std::unique_ptr<secp256k1_pubkey>& pk,
+             const std::shared_ptr<secp256k1_context>& ctx) -> evmc::address {
         static constexpr int uncompressed_pubkey_len = 65;
         auto pubkey_serialized
             = std::array<unsigned char, uncompressed_pubkey_len>();
@@ -84,9 +84,9 @@ namespace cbdc::parsec::agent::runner {
         return addr;
     }
 
-    auto eth_addr(const cbdc::privkey_t& key,
-                  const std::shared_ptr<secp256k1_context>& ctx)
-        -> evmc::address {
+    auto
+    eth_addr(const cbdc::privkey_t& key,
+             const std::shared_ptr<secp256k1_context>& ctx) -> evmc::address {
         auto pk = std::make_unique<secp256k1_pubkey>();
         [[maybe_unused]] const auto pub_ret
             = ::secp256k1_ec_pubkey_create(ctx.get(), pk.get(), key.data());

--- a/src/parsec/agent/runners/evm/address.hpp
+++ b/src/parsec/agent/runners/evm/address.hpp
@@ -41,17 +41,17 @@ namespace cbdc::parsec::agent::runner {
     /// \param key key to calculate the address for
     /// \param ctx secp256k1 context to use
     /// \return the address corresponding to the passed private key
-    auto eth_addr(const cbdc::privkey_t& key,
-                  const std::shared_ptr<secp256k1_context>& ctx)
-        -> evmc::address;
+    auto
+    eth_addr(const cbdc::privkey_t& key,
+             const std::shared_ptr<secp256k1_context>& ctx) -> evmc::address;
 
     /// Calculates an eth address from a public key
     /// \param pk key to calculate the address for
     /// \param ctx secp256k1 context to use
     /// \return the address corresponding to the passed public key
-    auto eth_addr(const std::unique_ptr<secp256k1_pubkey>& pk,
-                  const std::shared_ptr<secp256k1_context>& ctx)
-        -> evmc::address;
+    auto
+    eth_addr(const std::unique_ptr<secp256k1_pubkey>& pk,
+             const std::shared_ptr<secp256k1_context>& ctx) -> evmc::address;
 }
 
 #endif

--- a/src/parsec/agent/runners/evm/format.cpp
+++ b/src/parsec/agent/runners/evm/format.cpp
@@ -8,19 +8,19 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_account& acc)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_account& acc) -> serializer& {
         return ser << acc.m_balance << acc.m_nonce;
     }
 
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_account& acc)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_account& acc) -> serializer& {
         return deser >> acc.m_balance >> acc.m_nonce;
     }
 
-    auto operator<<(serializer& ser, const evmc::address& addr)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const evmc::address& addr) -> serializer& {
         ser.write(addr.bytes, sizeof(addr.bytes));
         return ser;
     }
@@ -40,12 +40,12 @@ namespace cbdc {
         return deser;
     }
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_sig& s)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::evm_sig& s) -> serializer& {
         return ser << s.m_v << s.m_r << s.m_s;
     }
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_sig& s)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_sig& s) -> serializer& {
         return deser >> s.m_v >> s.m_r >> s.m_s;
     }
 
@@ -55,30 +55,30 @@ namespace cbdc {
         return ser << at.m_address << at.m_storage_keys;
     }
 
-    auto operator>>(serializer& deser,
-                    parsec::agent::runner::evm_access_tuple& at)
-        -> serializer& {
+    auto
+    operator>>(serializer& deser,
+               parsec::agent::runner::evm_access_tuple& at) -> serializer& {
         return deser >> at.m_address >> at.m_storage_keys;
     }
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_tx& tx)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::evm_tx& tx) -> serializer& {
         return ser << tx.m_type << tx.m_to << tx.m_value << tx.m_nonce
                    << tx.m_gas_price << tx.m_gas_limit << tx.m_gas_tip_cap
                    << tx.m_gas_fee_cap << tx.m_input << tx.m_access_list
                    << tx.m_sig;
     }
 
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_tx& tx)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_tx& tx) -> serializer& {
         return deser >> tx.m_type >> tx.m_to >> tx.m_value >> tx.m_nonce
             >> tx.m_gas_price >> tx.m_gas_limit >> tx.m_gas_tip_cap
             >> tx.m_gas_fee_cap >> tx.m_input >> tx.m_access_list >> tx.m_sig;
     }
 
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_dryrun_tx& tx)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_dryrun_tx& tx) -> serializer& {
         return ser << tx.m_from << tx.m_tx;
     }
 
@@ -87,19 +87,19 @@ namespace cbdc {
         return deser >> tx.m_from >> tx.m_tx;
     }
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_log& l)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::evm_log& l) -> serializer& {
         return ser << l.m_addr << l.m_data << l.m_topics;
     }
 
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_log& l)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_log& l) -> serializer& {
         return deser >> l.m_addr >> l.m_data >> l.m_topics;
     }
 
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_tx_receipt& r)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_tx_receipt& r) -> serializer& {
         return ser << r.m_tx << r.m_create_address << r.m_gas_used << r.m_logs
                    << r.m_output_data << r.m_ticket_number << r.m_timestamp
                    << r.m_success;
@@ -112,30 +112,30 @@ namespace cbdc {
             >> r.m_timestamp >> r.m_success;
     }
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::code_key& k)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::code_key& k) -> serializer& {
         return ser << k.m_addr << uint8_t{};
     }
 
-    auto operator>>(serializer& deser, parsec::agent::runner::code_key& k)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::code_key& k) -> serializer& {
         uint8_t b{};
         return deser >> k.m_addr >> b;
     }
 
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::storage_key& k)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::storage_key& k) -> serializer& {
         return ser << k.m_addr << k.m_key;
     }
-    auto operator>>(serializer& deser, parsec::agent::runner::storage_key& k)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::storage_key& k) -> serializer& {
         return deser >> k.m_addr >> k.m_key;
     }
 
-    auto operator>>(serializer& deser,
-                    parsec::agent::runner::evm_pretend_block& b)
-        -> serializer& {
+    auto
+    operator>>(serializer& deser,
+               parsec::agent::runner::evm_pretend_block& b) -> serializer& {
         return deser >> b.m_ticket_number >> b.m_transactions;
     }
     auto operator<<(serializer& ser,
@@ -149,9 +149,9 @@ namespace cbdc {
         return deser >> lq.m_addresses >> lq.m_from_block >> lq.m_to_block
             >> lq.m_topics;
     }
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_log_query& lq)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_log_query& lq) -> serializer& {
         return ser << lq.m_addresses << lq.m_from_block << lq.m_to_block
                    << lq.m_topics;
     }

--- a/src/parsec/agent/runners/evm/format.hpp
+++ b/src/parsec/agent/runners/evm/format.hpp
@@ -10,11 +10,11 @@
 #include "util/serialization/serializer.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_account& acc)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_account& acc)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_account& acc) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_account& acc) -> serializer&;
 
     auto operator<<(serializer& ser, const evmc::address& addr) -> serializer&;
     auto operator>>(serializer& deser, evmc::address& addr) -> serializer&;
@@ -22,69 +22,69 @@ namespace cbdc {
     auto operator<<(serializer& ser, const evmc::bytes32& b) -> serializer&;
     auto operator>>(serializer& deser, evmc::bytes32& b) -> serializer&;
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_tx& tx)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_tx& tx)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::evm_tx& tx) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_tx& tx) -> serializer&;
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_sig& s)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_sig& s)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::evm_sig& s) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_sig& s) -> serializer&;
 
     auto operator<<(serializer& ser,
                     const parsec::agent::runner::evm_access_tuple& at)
         -> serializer&;
-    auto operator>>(serializer& deser,
-                    parsec::agent::runner::evm_access_tuple& at)
-        -> serializer&;
-
-    auto operator<<(serializer& ser, const parsec::agent::runner::evm_log& l)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::evm_log& l)
-        -> serializer&;
+    auto
+    operator>>(serializer& deser,
+               parsec::agent::runner::evm_access_tuple& at) -> serializer&;
 
     auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_tx_receipt& r)
-        -> serializer&;
+                    const parsec::agent::runner::evm_log& l) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::evm_log& l) -> serializer&;
+
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_tx_receipt& r) -> serializer&;
     auto operator>>(serializer& deser,
                     parsec::agent::runner::evm_tx_receipt& r) -> serializer&;
 
-    auto operator<<(serializer& ser, const parsec::agent::runner::code_key& k)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::code_key& k)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const parsec::agent::runner::code_key& k) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::code_key& k) -> serializer&;
 
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::storage_key& k)
-        -> serializer&;
-    auto operator>>(serializer& deser, parsec::agent::runner::storage_key& k)
-        -> serializer&;
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_dryrun_tx& tx)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::storage_key& k) -> serializer&;
+    auto operator>>(serializer& deser,
+                    parsec::agent::runner::storage_key& k) -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_dryrun_tx& tx) -> serializer&;
 
     auto operator>>(serializer& deser,
                     parsec::agent::runner::evm_dryrun_tx& tx) -> serializer&;
 
-    auto operator>>(serializer& deser,
-                    parsec::agent::runner::evm_pretend_block& b)
-        -> serializer&;
+    auto
+    operator>>(serializer& deser,
+               parsec::agent::runner::evm_pretend_block& b) -> serializer&;
     auto operator<<(serializer& ser,
                     const parsec::agent::runner::evm_pretend_block& b)
         -> serializer&;
 
     auto operator>>(serializer& deser,
                     parsec::agent::runner::evm_log_query& lq) -> serializer&;
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_log_query& lq)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_log_query& lq) -> serializer&;
 
     auto operator>>(serializer& deser,
                     parsec::agent::runner::evm_log_index& idx) -> serializer&;
-    auto operator<<(serializer& ser,
-                    const parsec::agent::runner::evm_log_index& idx)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::agent::runner::evm_log_index& idx) -> serializer&;
 }
 
 #endif

--- a/src/parsec/agent/runners/evm/host.cpp
+++ b/src/parsec/agent/runners/evm/host.cpp
@@ -214,9 +214,9 @@ namespace cbdc::parsec::agent::runner {
         return n;
     }
 
-    auto evm_host::selfdestruct(const evmc::address& addr,
-                                const evmc::address& beneficiary) noexcept
-        -> bool {
+    auto
+    evm_host::selfdestruct(const evmc::address& addr,
+                           const evmc::address& beneficiary) noexcept -> bool {
         m_log->trace("EVM selfdestruct:", to_hex(addr), to_hex(beneficiary));
         // TODO: delete storage keys and code
         transfer(addr, beneficiary, evmc::uint256be{});
@@ -432,10 +432,9 @@ namespace cbdc::parsec::agent::runner {
         return make_buffer(tn_hash);
     }
 
-    auto evm_host::log_index_key(
-        evmc::address addr,
-        std::optional<interface::ticket_number_type> tn) const
-        -> cbdc::buffer {
+    auto evm_host::log_index_key(evmc::address addr,
+                                 std::optional<interface::ticket_number_type>
+                                     tn) const -> cbdc::buffer {
         if(!tn) {
             tn = m_ticket_number;
         }
@@ -640,9 +639,8 @@ namespace cbdc::parsec::agent::runner {
         return data;
     }
 
-    auto evm_host::get_account_code(const evmc::address& addr,
-                                    bool write) const
-        -> std::optional<evm_account_code> {
+    auto evm_host::get_account_code(const evmc::address& addr, bool write)
+        const -> std::optional<evm_account_code> {
         m_log->trace("EVM request account code:", to_hex(addr));
 
         if(is_precompile(addr)) {

--- a/src/parsec/agent/runners/evm/host.hpp
+++ b/src/parsec/agent/runners/evm/host.hpp
@@ -38,9 +38,8 @@ namespace cbdc::parsec::agent::runner {
                  bool is_readonly_run,
                  interface::ticket_number_type ticket_number);
 
-        [[nodiscard]] auto
-        account_exists(const evmc::address& addr) const noexcept
-            -> bool override;
+        [[nodiscard]] auto account_exists(
+            const evmc::address& addr) const noexcept -> bool override;
 
         [[nodiscard]] auto get_storage(const evmc::address& addr,
                                        const evmc::bytes32& key) const noexcept
@@ -51,33 +50,30 @@ namespace cbdc::parsec::agent::runner {
                          const evmc::bytes32& value) noexcept
             -> evmc_storage_status override final;
 
-        [[nodiscard]] auto
-        get_balance(const evmc::address& addr) const noexcept
-            -> evmc::uint256be override final;
+        [[nodiscard]] auto get_balance(const evmc::address& addr)
+            const noexcept -> evmc::uint256be override final;
 
-        [[nodiscard]] auto
-        get_code_size(const evmc::address& addr) const noexcept
-            -> size_t override final;
+        [[nodiscard]] auto get_code_size(
+            const evmc::address& addr) const noexcept -> size_t override final;
 
-        [[nodiscard]] auto
-        get_code_hash(const evmc::address& addr) const noexcept
-            -> evmc::bytes32 override final;
+        [[nodiscard]] auto get_code_hash(const evmc::address& addr)
+            const noexcept -> evmc::bytes32 override final;
 
-        auto copy_code(const evmc::address& addr,
-                       size_t code_offset,
-                       uint8_t* buffer_data,
-                       size_t buffer_size) const noexcept
-            -> size_t override final;
+        auto
+        copy_code(const evmc::address& addr,
+                  size_t code_offset,
+                  uint8_t* buffer_data,
+                  size_t buffer_size) const noexcept -> size_t override final;
 
         auto selfdestruct(const evmc::address& addr,
                           const evmc::address& beneficiary) noexcept
             -> bool override final;
 
-        auto call(const evmc_message& msg) noexcept
-            -> evmc::Result override final;
+        auto
+        call(const evmc_message& msg) noexcept -> evmc::Result override final;
 
-        [[nodiscard]] auto get_tx_context() const noexcept
-            -> evmc_tx_context override final;
+        [[nodiscard]] auto
+        get_tx_context() const noexcept -> evmc_tx_context override final;
 
         [[nodiscard]] auto get_block_hash(int64_t number) const noexcept
             -> evmc::bytes32 override final;
@@ -110,8 +106,8 @@ namespace cbdc::parsec::agent::runner {
         /// Return the changes to the state resulting from transaction
         /// execution.
         /// \return list of updates keys and values.
-        auto get_state_updates() const
-            -> runtime_locking_shard::state_update_type;
+        auto
+        get_state_updates() const -> runtime_locking_shard::state_update_type;
 
         /// Returns whether the transaction needs to be retried due to a
         /// transient error.
@@ -179,18 +175,18 @@ namespace cbdc::parsec::agent::runner {
 
         interface::ticket_number_type m_ticket_number;
 
-        [[nodiscard]] auto get_account(const evmc::address& addr,
-                                       bool write) const
-            -> std::optional<evm_account>;
+        [[nodiscard]] auto
+        get_account(const evmc::address& addr,
+                    bool write) const -> std::optional<evm_account>;
 
-        [[nodiscard]] auto get_account_storage(const evmc::address& addr,
-                                               const evmc::bytes32& key,
-                                               bool write) const
-            -> std::optional<evmc::bytes32>;
+        [[nodiscard]] auto
+        get_account_storage(const evmc::address& addr,
+                            const evmc::bytes32& key,
+                            bool write) const -> std::optional<evmc::bytes32>;
 
-        [[nodiscard]] auto get_account_code(const evmc::address& addr,
-                                            bool write) const
-            -> std::optional<evm_account_code>;
+        [[nodiscard]] auto
+        get_account_code(const evmc::address& addr,
+                         bool write) const -> std::optional<evm_account_code>;
 
         auto get_sorted_logs() const
             -> std::unordered_map<evmc::address, std::vector<evm_log>>;

--- a/src/parsec/agent/runners/evm/http_server.cpp
+++ b/src/parsec/agent/runners/evm/http_server.cpp
@@ -64,11 +64,10 @@ namespace cbdc::parsec::agent::rpc {
         return handle_unsupported(method, params, callback);
     }
 
-    auto http_server::handle_supported(
-        const std::string& method,
-        const Json::Value& params,
-        const server_type::result_callback_type& callback)
-        -> std::optional<bool> {
+    auto http_server::handle_supported(const std::string& method,
+                                       const Json::Value& params,
+                                       const server_type::result_callback_type&
+                                           callback) -> std::optional<bool> {
         if(method == "eth_sendRawTransaction") {
             return handle_send_raw_transaction(params, callback);
         }
@@ -143,11 +142,10 @@ namespace cbdc::parsec::agent::rpc {
         return std::nullopt;
     }
 
-    auto http_server::handle_static(
-        const std::string& method,
-        const Json::Value& params,
-        const server_type::result_callback_type& callback)
-        -> std::optional<bool> {
+    auto http_server::handle_static(const std::string& method,
+                                    const Json::Value& params,
+                                    const server_type::result_callback_type&
+                                        callback) -> std::optional<bool> {
         if(method == "eth_chainId" || method == "net_version") {
             return handle_chain_id(params, callback);
         }
@@ -1106,10 +1104,9 @@ namespace cbdc::parsec::agent::rpc {
             });
     }
 
-    auto
-    http_server::handle_sha3(Json::Value params,
-                             const server_type::result_callback_type& callback)
-        -> bool {
+    auto http_server::handle_sha3(
+        Json::Value params,
+        const server_type::result_callback_type& callback) -> bool {
         if(!params.isArray() || params.empty() || !params[0].isString()) {
             m_log->warn("Invalid parameters to sha3");
             return false;
@@ -1278,10 +1275,9 @@ namespace cbdc::parsec::agent::rpc {
         return true;
     }
 
-    auto
-    http_server::handle_call(Json::Value params,
-                             const server_type::result_callback_type& callback)
-        -> bool {
+    auto http_server::handle_call(
+        Json::Value params,
+        const server_type::result_callback_type& callback) -> bool {
         if(!params.isArray() || params.empty() || !params[0].isObject()) {
             m_log->warn("Parameter to call is invalid");
             auto ret = Json::Value();

--- a/src/parsec/agent/runners/evm/http_server.hpp
+++ b/src/parsec/agent/runners/evm/http_server.hpp
@@ -88,43 +88,38 @@ namespace cbdc::parsec::agent::rpc {
             Json::Value params,
             const server_type::result_callback_type& callback) -> bool;
 
-        static auto
-        handle_chain_id(const Json::Value& params,
-                        const server_type::result_callback_type& callback)
-            -> bool;
+        static auto handle_chain_id(
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
 
-        auto handle_call(Json::Value params,
-                         const server_type::result_callback_type& callback)
-            -> bool;
+        auto
+        handle_call(Json::Value params,
+                    const server_type::result_callback_type& callback) -> bool;
 
         auto handle_send_transaction(
             Json::Value params,
             const server_type::result_callback_type& callback) -> bool;
 
-        static auto
-        handle_estimate_gas(const Json::Value& params,
-                            const server_type::result_callback_type& callback)
-            -> bool;
+        static auto handle_estimate_gas(
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
 
         static auto handle_client_version(
             const Json::Value& params,
             const server_type::result_callback_type& callback) -> bool;
-        static auto
-        handle_gas_price(const Json::Value& params,
-                         const server_type::result_callback_type& callback)
-            -> bool;
+        static auto handle_gas_price(
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
 
         auto handle_get_code(Json::Value params,
                              const server_type::result_callback_type& callback)
             -> bool;
-        auto
-        handle_get_balance(Json::Value params,
-                           const server_type::result_callback_type& callback)
-            -> bool;
-        static auto
-        handle_accounts(const Json::Value& params,
-                        const server_type::result_callback_type& callback)
-            -> bool;
+        auto handle_get_balance(
+            Json::Value params,
+            const server_type::result_callback_type& callback) -> bool;
+        static auto handle_accounts(
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
 
         auto handle_get_transaction_by_hash(
             Json::Value params,
@@ -134,30 +129,25 @@ namespace cbdc::parsec::agent::rpc {
             Json::Value params,
             const server_type::result_callback_type& callback) -> bool;
 
-        auto
-        handle_not_supported(Json::Value params,
-                             const server_type::result_callback_type& callback)
-            -> bool;
+        auto handle_not_supported(
+            Json::Value params,
+            const server_type::result_callback_type& callback) -> bool;
 
-        auto
-        handle_block_number(const Json::Value& params,
-                            const server_type::result_callback_type& callback)
-            -> bool;
-        auto
-        handle_get_block(Json::Value params,
-                         const server_type::result_callback_type& callback)
-            -> bool;
+        auto handle_block_number(
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
+        auto handle_get_block(
+            Json::Value params,
+            const server_type::result_callback_type& callback) -> bool;
         auto handle_get_block_txcount(
             Json::Value params,
             const server_type::result_callback_type& callback) -> bool;
-        auto
-        handle_get_block_tx(Json::Value params,
-                            const server_type::result_callback_type& callback)
-            -> bool;
-        auto
-        handle_fee_history(Json::Value params,
-                           const server_type::result_callback_type& callback)
-            -> bool;
+        auto handle_get_block_tx(
+            Json::Value params,
+            const server_type::result_callback_type& callback) -> bool;
+        auto handle_fee_history(
+            Json::Value params,
+            const server_type::result_callback_type& callback) -> bool;
         auto handle_get_logs(Json::Value params,
                              const server_type::result_callback_type& callback)
             -> bool;
@@ -165,9 +155,9 @@ namespace cbdc::parsec::agent::rpc {
             Json::Value params,
             const server_type::result_callback_type& callback) -> bool;
 
-        auto handle_sha3(Json::Value params,
-                         const server_type::result_callback_type& callback)
-            -> bool;
+        auto
+        handle_sha3(Json::Value params,
+                    const server_type::result_callback_type& callback) -> bool;
 
         static auto
         handle_error(const Json::Value& params,
@@ -194,11 +184,11 @@ namespace cbdc::parsec::agent::rpc {
                             const server_type::result_callback_type& callback)
             -> std::optional<parsec::agent::runner::evm_log_query>;
 
-        auto fetch_block(Json::Value params,
-                         const server_type::result_callback_type& callback,
-                         const std::function<void(interface::exec_return_type,
-                                                  cbdc::buffer)>& res_cb)
-            -> bool;
+        auto
+        fetch_block(Json::Value params,
+                    const server_type::result_callback_type& callback,
+                    const std::function<void(interface::exec_return_type,
+                                             cbdc::buffer)>& res_cb) -> bool;
 
         auto
         exec_tx(const server_type::result_callback_type& json_ret_callback,
@@ -208,11 +198,10 @@ namespace cbdc::parsec::agent::rpc {
                 const std::function<void(interface::exec_return_type)>&
                     res_success_cb) -> bool;
 
-        auto
-        handle_unsupported(const std::string& method,
-                           const Json::Value& params,
-                           const server_type::result_callback_type& callback)
-            -> bool;
+        auto handle_unsupported(
+            const std::string& method,
+            const Json::Value& params,
+            const server_type::result_callback_type& callback) -> bool;
 
         auto
         handle_supported(const std::string& method,

--- a/src/parsec/agent/runners/evm/impl.hpp
+++ b/src/parsec/agent/runners/evm/impl.hpp
@@ -98,14 +98,14 @@ namespace cbdc::parsec::agent::runner {
         [[nodiscard]] static auto check_base_gas(const evm_tx& tx,
                                                  bool is_readonly_run)
             -> std::pair<evmc::uint256be, bool>;
-        [[nodiscard]] static auto make_tx_context(const evmc::address& from,
-                                                  const evm_tx& tx,
-                                                  bool is_readonly_run)
-            -> evmc_tx_context;
-        static auto make_message(const evmc::address& from,
-                                 const evm_tx& tx,
-                                 bool is_readonly_run)
-            -> std::pair<evmc_message, bool>;
+        [[nodiscard]] static auto
+        make_tx_context(const evmc::address& from,
+                        const evm_tx& tx,
+                        bool is_readonly_run) -> evmc_tx_context;
+        static auto
+        make_message(const evmc::address& from,
+                     const evm_tx& tx,
+                     bool is_readonly_run) -> std::pair<evmc_message, bool>;
 
         void handle_lock_from_account(
             const broker::interface::try_lock_return_type& res);

--- a/src/parsec/agent/runners/evm/math.cpp
+++ b/src/parsec/agent/runners/evm/math.cpp
@@ -11,8 +11,8 @@
 // to access the data behind evmc::uint256be.
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
 namespace cbdc::parsec::agent::runner {
-    auto operator+(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be {
+    auto operator+(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be {
         auto ret = evmc::uint256be{};
         auto tmp = uint64_t{};
         auto carry = uint8_t{};
@@ -25,8 +25,8 @@ namespace cbdc::parsec::agent::runner {
         return ret;
     }
 
-    auto operator-(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be {
+    auto operator-(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be {
         auto ret = evmc::uint256be{};
         auto tmp1 = uint64_t{};
         auto tmp2 = uint64_t{};
@@ -43,8 +43,8 @@ namespace cbdc::parsec::agent::runner {
         return ret;
     }
 
-    auto operator*(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be {
+    auto operator*(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be {
         auto ret = evmc::uint256be{};
         for(size_t i = 0; i < sizeof(lhs.bytes); i++) {
             auto row = evmc::uint256be{};
@@ -71,8 +71,8 @@ namespace cbdc::parsec::agent::runner {
         return ret;
     }
 
-    auto operator<<(const evmc::uint256be& lhs, size_t count)
-        -> evmc::uint256be {
+    auto operator<<(const evmc::uint256be& lhs,
+                    size_t count) -> evmc::uint256be {
         auto ret = evmc::uint256be{};
         if(count >= sizeof(lhs.bytes)) {
             return ret;

--- a/src/parsec/agent/runners/evm/math.hpp
+++ b/src/parsec/agent/runners/evm/math.hpp
@@ -13,29 +13,29 @@ namespace cbdc::parsec::agent::runner {
     /// \param lhs first value.
     /// \param rhs second value.
     /// \return sum of both values.
-    auto operator+(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be;
+    auto operator+(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be;
 
     /// Subtracts two uint256be values.
     /// \param lhs value to subtract from.
     /// \param rhs value to subtract.
     /// \return lhs - rhs
-    auto operator-(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be;
+    auto operator-(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be;
 
     /// Multiplies two uint256be values
     /// \param lhs first value.
     /// \param rhs second value.
     /// \return lhs * rhs
-    auto operator*(const evmc::uint256be& lhs, const evmc::uint256be& rhs)
-        -> evmc::uint256be;
+    auto operator*(const evmc::uint256be& lhs,
+                   const evmc::uint256be& rhs) -> evmc::uint256be;
 
     /// Left shifts a uint256be value by a given number of bytes.
     /// \param lhs value to shift.
     /// \param count number of bytes to shift by.
     /// \return lhs left shifted by count bytes.
-    auto operator<<(const evmc::uint256be& lhs, size_t count)
-        -> evmc::uint256be;
+    auto operator<<(const evmc::uint256be& lhs,
+                    size_t count) -> evmc::uint256be;
 }
 
 #endif

--- a/src/parsec/agent/runners/evm/messages.hpp
+++ b/src/parsec/agent/runners/evm/messages.hpp
@@ -121,7 +121,7 @@ namespace cbdc::parsec::agent::runner {
         /// Ticket number that ran this TX - needed to map
         /// to pretend blocks
         cbdc::parsec::agent::runner::interface::ticket_number_type
-            m_ticket_number {};
+            m_ticket_number{};
         /// Timestamp of the transaction - needed to provide
         /// a timestamp in pretend blocks
         uint64_t m_timestamp{};
@@ -134,7 +134,7 @@ namespace cbdc::parsec::agent::runner {
     /// the block" (executed by that ticket)
     struct evm_pretend_block {
         /// Ticket number
-        interface::ticket_number_type m_ticket_number {};
+        interface::ticket_number_type m_ticket_number{};
         /// Transactions executed by the ticket
         std::vector<evm_tx_receipt> m_transactions{};
     };
@@ -148,10 +148,10 @@ namespace cbdc::parsec::agent::runner {
         std::vector<evmc::bytes32> m_topics{};
         /// The start of the block range to query logs for
         cbdc::parsec::agent::runner::interface::ticket_number_type
-            m_from_block {};
+            m_from_block{};
         /// The end of the block range to query logs for
-        cbdc::parsec::agent::runner::interface::ticket_number_type m_to_block {
-        };
+        cbdc::parsec::agent::runner::interface::ticket_number_type
+            m_to_block{};
     };
 
     /// Index data for evm logs. This is the value stored under a key
@@ -162,7 +162,7 @@ namespace cbdc::parsec::agent::runner {
     /// related to a particular address
     struct evm_log_index {
         /// Ticket number that emitted the logs
-        interface::ticket_number_type m_ticket_number {};
+        interface::ticket_number_type m_ticket_number{};
         /// TXID that emitted the logs
         cbdc::hash_t m_txid{};
         /// The logs that were emitted

--- a/src/parsec/agent/runners/evm/rlp.hpp
+++ b/src/parsec/agent/runners/evm/rlp.hpp
@@ -90,10 +90,11 @@ namespace cbdc {
         /// \tparam address or byte array type.
         /// \return byte array or address.
         template<typename T>
-        [[nodiscard]] auto value() const -> typename std::enable_if_t<
-            std::is_same<T, evmc::bytes32>::value
-                || std::is_same<T, evmc::address>::value,
-            T> {
+        [[nodiscard]] auto value() const ->
+            typename std::enable_if_t<
+                std::is_same<T, evmc::bytes32>::value
+                    || std::is_same<T, evmc::address>::value,
+                T> {
             auto res = T();
             auto buf = cbdc::buffer();
             buf.extend(sizeof(res.bytes));
@@ -123,8 +124,8 @@ namespace cbdc {
     /// before turning it into an rlp_value
     /// \return rlp_value of type buffer with the passed object as contents
     template<typename T>
-    auto make_rlp_value(const T& obj, bool trim_leading_zeroes = false)
-        -> rlp_value {
+    auto make_rlp_value(const T& obj,
+                        bool trim_leading_zeroes = false) -> rlp_value {
         auto pkt = make_buffer(obj);
         if(trim_leading_zeroes) {
             size_t start_idx = 0;
@@ -177,9 +178,8 @@ namespace cbdc {
     /// RLP encodes an access list
     /// \param access_list the access list to encode
     /// \return rlp_value of type rlp_value_array with the access list as contents
-    auto rlp_encode_access_list(
-        const parsec::agent::runner::evm_access_list& access_list)
-        -> rlp_value;
+    auto rlp_encode_access_list(const parsec::agent::runner::evm_access_list&
+                                    access_list) -> rlp_value;
 
     /// Decodes an access list from and rlp_value of type rlp_value_type::array
     /// \param rlp rlp_value to decode from

--- a/src/parsec/agent/runners/evm/rlp_writer.cpp
+++ b/src/parsec/agent/runners/evm/rlp_writer.cpp
@@ -82,9 +82,8 @@ namespace cbdc {
         return vec;
     }
 
-    auto rlp_encode_access_list(
-        const parsec::agent::runner::evm_access_list& access_list)
-        -> rlp_value {
+    auto rlp_encode_access_list(const parsec::agent::runner::evm_access_list&
+                                    access_list) -> rlp_value {
         auto rlp_access_list
             = rlp_value(rlp_value_type::array); // empty by default
         if(!access_list.empty()) {

--- a/src/parsec/agent/runners/evm/serialization.cpp
+++ b/src/parsec/agent/runners/evm/serialization.cpp
@@ -255,8 +255,8 @@ namespace cbdc::parsec::agent::runner {
         return std::nullopt;
     }
 
-    auto buffer_from_json(const Json::Value& val)
-        -> std::optional<cbdc::buffer> {
+    auto
+    buffer_from_json(const Json::Value& val) -> std::optional<cbdc::buffer> {
         if(!val.empty() && val.isString()) {
             auto val_str = val.asString();
             if(val_str.size() > 2) {
@@ -266,8 +266,8 @@ namespace cbdc::parsec::agent::runner {
         return std::nullopt;
     }
 
-    auto uint256be_or_default(const Json::Value& val, evmc::uint256be def)
-        -> evmc::uint256be {
+    auto uint256be_or_default(const Json::Value& val,
+                              evmc::uint256be def) -> evmc::uint256be {
         auto maybe_ui256 = uint256be_from_json(val);
         if(maybe_ui256) {
             return maybe_ui256.value();
@@ -275,8 +275,9 @@ namespace cbdc::parsec::agent::runner {
         return def;
     }
 
-    auto raw_tx_from_json(const Json::Value& param) -> std::optional<
-        std::shared_ptr<cbdc::parsec::agent::runner::evm_tx>> {
+    auto raw_tx_from_json(const Json::Value& param)
+        -> std::optional<
+            std::shared_ptr<cbdc::parsec::agent::runner::evm_tx>> {
         if(!param.isString()) {
             return std::nullopt;
         }
@@ -334,9 +335,9 @@ namespace cbdc::parsec::agent::runner {
         return tx;
     }
 
-    auto tx_to_json(cbdc::parsec::agent::runner::evm_tx& tx,
-                    const std::shared_ptr<secp256k1_context>& ctx)
-        -> Json::Value {
+    auto
+    tx_to_json(cbdc::parsec::agent::runner::evm_tx& tx,
+               const std::shared_ptr<secp256k1_context>& ctx) -> Json::Value {
         auto res = Json::Value();
         res["type"] = to_hex_trimmed(
             evmc::uint256be(static_cast<uint64_t>(tx.m_type)));

--- a/src/parsec/agent/runners/evm/serialization.hpp
+++ b/src/parsec/agent/runners/evm/serialization.hpp
@@ -84,8 +84,8 @@ namespace cbdc::parsec::agent::runner {
     ///             to be a string in 0x... format
     /// \return the evmc::address that was decoded or std::nullopt if no valid
     ///         value could be decoded
-    auto address_from_json(const Json::Value& addr)
-        -> std::optional<evmc::address>;
+    auto
+    address_from_json(const Json::Value& addr) -> std::optional<evmc::address>;
 
     /// Converts a given Json::Value to an evmc::uint256be
     /// \param val Json::Value containing the uint256be to decode. Is expected
@@ -101,8 +101,8 @@ namespace cbdc::parsec::agent::runner {
     ///            representation of the buffer
     /// \return the cbdc::buffer that was decoded or std::nullopt if no valid
     ///         value could be decoded
-    auto buffer_from_json(const Json::Value& val)
-        -> std::optional<cbdc::buffer>;
+    auto
+    buffer_from_json(const Json::Value& val) -> std::optional<cbdc::buffer>;
 
     /// Converts a given Json::Value to an evmc::uint256be, returning a default
     /// value if none could be decoded
@@ -113,8 +113,8 @@ namespace cbdc::parsec::agent::runner {
     ///            val
     /// \return the evmc::uint256be that was decoded or the value of def if no
     ///         value could be decoded
-    auto uint256be_or_default(const Json::Value& val, evmc::uint256be def)
-        -> evmc::uint256be;
+    auto uint256be_or_default(const Json::Value& val,
+                              evmc::uint256be def) -> evmc::uint256be;
 
     /// Encodes the given transaction into a eth-RPC compatible representation
     /// in JSON - as Json::Value
@@ -122,9 +122,9 @@ namespace cbdc::parsec::agent::runner {
     /// \param ctx The secp256k1 context to use for deriving the from address
     /// \return a Json::Value containing the json representation of the
     ///         transaction
-    auto tx_to_json(cbdc::parsec::agent::runner::evm_tx& tx,
-                    const std::shared_ptr<secp256k1_context>& ctx)
-        -> Json::Value;
+    auto
+    tx_to_json(cbdc::parsec::agent::runner::evm_tx& tx,
+               const std::shared_ptr<secp256k1_context>& ctx) -> Json::Value;
 
     /// Encodes the given transaction receipt into a eth-RPC compatible
     /// representation in JSON - as Json::Value

--- a/src/parsec/agent/runners/evm/signature.hpp
+++ b/src/parsec/agent/runners/evm/signature.hpp
@@ -41,8 +41,8 @@ namespace cbdc::parsec::agent::runner {
     /// nullopt otherwise
     auto check_signature(const cbdc::parsec::agent::runner::evm_tx& tx,
                          const std::shared_ptr<secp256k1_context>& ctx,
-                         uint64_t chain_id = opencbdc_chain_id)
-        -> std::optional<evmc::address>;
+                         uint64_t chain_id
+                         = opencbdc_chain_id) -> std::optional<evmc::address>;
 
     /// Calculates the hash for creating / validating the signature
     /// \param tx transaction to calculate the sighash for

--- a/src/parsec/agent/runners/evm/util.cpp
+++ b/src/parsec/agent/runners/evm/util.cpp
@@ -32,8 +32,8 @@ namespace cbdc::parsec::agent::runner {
         return evmc::hex(evmc::bytes(b.bytes, sizeof(b.bytes)));
     }
 
-    auto to_hex_trimmed(const evmc::bytes32& b, const std::string& prefix)
-        -> std::string {
+    auto to_hex_trimmed(const evmc::bytes32& b,
+                        const std::string& prefix) -> std::string {
         auto b_vec = std::vector<uint8_t>();
         b_vec.resize(sizeof(b.bytes));
         std::memcpy(b_vec.data(), &b.bytes[0], sizeof(b.bytes));

--- a/src/parsec/agent/runners/lua/server.hpp
+++ b/src/parsec/agent/runners/lua/server.hpp
@@ -44,9 +44,9 @@ namespace cbdc::parsec::agent::rpc {
       private:
         std::unique_ptr<server_type> m_srv;
 
-        auto request_handler(request req,
-                             server_type::response_callback_type callback)
-            -> bool;
+        auto
+        request_handler(request req,
+                        server_type::response_callback_type callback) -> bool;
     };
 }
 

--- a/src/parsec/broker/interface.hpp
+++ b/src/parsec/broker/interface.hpp
@@ -93,9 +93,8 @@ namespace cbdc::parsec::broker {
         /// Acquires a new ticket number to begin a transaction.
         /// \param result_callback function to call with begin result.
         /// \return true if the operation was initiated successfully.
-        [[nodiscard]] virtual auto begin(begin_callback_type result_callback)
-            -> bool
-            = 0;
+        [[nodiscard]] virtual auto
+        begin(begin_callback_type result_callback) -> bool = 0;
 
         /// Return type from a try lock operation. Either the value associated
         /// with the requested key, a broker error, or a shard error.
@@ -117,8 +116,7 @@ namespace cbdc::parsec::broker {
         try_lock(ticket_number_type ticket_number,
                  key_type key,
                  lock_type locktype,
-                 try_lock_callback_type result_callback) -> bool
-            = 0;
+                 try_lock_callback_type result_callback) -> bool = 0;
 
         /// Return type from a commit operation. Broker or shard error code, if
         /// applicable.
@@ -132,11 +130,10 @@ namespace cbdc::parsec::broker {
         /// \param state_updates state updates to commit.
         /// \param result_callback function to call with commit result.
         /// \return true if the operation was initiated successfully.
-        [[nodiscard]] virtual auto commit(ticket_number_type ticket_number,
-                                          state_update_type state_updates,
-                                          commit_callback_type result_callback)
-            -> bool
-            = 0;
+        [[nodiscard]] virtual auto
+        commit(ticket_number_type ticket_number,
+               state_update_type state_updates,
+               commit_callback_type result_callback) -> bool = 0;
 
         /// Return type from a finish operation. Broker error code, if
         /// applicable.
@@ -148,10 +145,9 @@ namespace cbdc::parsec::broker {
         /// \param ticket_number ticket number.
         /// \param result_callback function to call with finish result.
         /// \return true if the operation was initiated successfully.
-        [[nodiscard]] virtual auto finish(ticket_number_type ticket_number,
-                                          finish_callback_type result_callback)
-            -> bool
-            = 0;
+        [[nodiscard]] virtual auto
+        finish(ticket_number_type ticket_number,
+               finish_callback_type result_callback) -> bool = 0;
 
         /// Return type from a rollback operation. Broker or shard error code,
         /// if applicable.
@@ -167,8 +163,7 @@ namespace cbdc::parsec::broker {
         /// \return true if the operation was initiated successfully.
         [[nodiscard]] virtual auto
         rollback(ticket_number_type ticket_number,
-                 rollback_callback_type result_callback) -> bool
-            = 0;
+                 rollback_callback_type result_callback) -> bool = 0;
 
         /// Return type from a recover operation. Broker error code, if
         /// applicable.
@@ -182,8 +177,7 @@ namespace cbdc::parsec::broker {
         /// \param result_callback function to call with recovery result.
         /// \return true if the operation was initated successfully.
         [[nodiscard]] virtual auto
-        recover(recover_callback_type result_callback) -> bool
-            = 0;
+        recover(recover_callback_type result_callback) -> bool = 0;
 
         /// Get the highest ticket number that was used. This is not to be
         /// used for calculating a next ticket number, but is used to calculate

--- a/src/parsec/directory/impl.cpp
+++ b/src/parsec/directory/impl.cpp
@@ -8,9 +8,9 @@
 namespace cbdc::parsec::directory {
     impl::impl(size_t n_shards) : m_n_shards(n_shards) {}
 
-    auto impl::key_location(runtime_locking_shard::key_type key,
-                            key_location_callback_type result_callback)
-        -> bool {
+    auto
+    impl::key_location(runtime_locking_shard::key_type key,
+                       key_location_callback_type result_callback) -> bool {
         auto key_hash = m_siphash(key);
         // NOTE: using modulo creates a small bias from a true
         // uniform distribution

--- a/src/parsec/directory/interface.hpp
+++ b/src/parsec/directory/interface.hpp
@@ -30,10 +30,9 @@ namespace cbdc::parsec::directory {
         /// \param key key to locate.
         /// \param result_callback function to call with key location.
         /// \return true if the operation was initiated successfully.
-        virtual auto key_location(runtime_locking_shard::key_type key,
-                                  key_location_callback_type result_callback)
-            -> bool
-            = 0;
+        virtual auto
+        key_location(runtime_locking_shard::key_type key,
+                     key_location_callback_type result_callback) -> bool = 0;
     };
 }
 

--- a/src/parsec/runtime_locking_shard/client.cpp
+++ b/src/parsec/runtime_locking_shard/client.cpp
@@ -11,7 +11,7 @@
 namespace cbdc::parsec::runtime_locking_shard::rpc {
     client::client(std::vector<network::endpoint_t> endpoints)
         : m_client(std::make_unique<decltype(m_client)::element_type>(
-            std::move(endpoints))) {}
+              std::move(endpoints))) {}
 
     auto client::init() -> bool {
         return m_client->init();
@@ -92,9 +92,9 @@ namespace cbdc::parsec::runtime_locking_shard::rpc {
             });
     }
 
-    auto client::get_tickets(broker_id_type broker_id,
-                             get_tickets_callback_type result_callback)
-        -> bool {
+    auto
+    client::get_tickets(broker_id_type broker_id,
+                        get_tickets_callback_type result_callback) -> bool {
         auto req = get_tickets_request{broker_id};
         return m_client->call(
             req,

--- a/src/parsec/runtime_locking_shard/format.cpp
+++ b/src/parsec/runtime_locking_shard/format.cpp
@@ -122,23 +122,23 @@ namespace cbdc {
             >> req.m_state_update;
     }
 
-    auto operator<<(serializer& ser,
-                    const parsec::runtime_locking_shard::rpc::
-                        replicated_get_tickets_request& /* req */)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::runtime_locking_shard::rpc::
+                   replicated_get_tickets_request& /* req */) -> serializer& {
         return ser;
     }
-    auto operator>>(serializer& deser,
-                    parsec::runtime_locking_shard::rpc::
-                        replicated_get_tickets_request& /* req */)
-        -> serializer& {
+    auto
+    operator>>(serializer& deser,
+               parsec::runtime_locking_shard::rpc::
+                   replicated_get_tickets_request& /* req */) -> serializer& {
         return deser;
     }
 
-    auto operator<<(serializer& ser,
-                    const parsec::runtime_locking_shard::
-                        replicated_shard_interface::ticket_type& t)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const parsec::runtime_locking_shard::
+                   replicated_shard_interface::ticket_type& t) -> serializer& {
         return ser << t.m_state << t.m_broker_id << t.m_state_update;
     }
     auto operator>>(

--- a/src/parsec/runtime_locking_shard/format.hpp
+++ b/src/parsec/runtime_locking_shard/format.hpp
@@ -62,9 +62,9 @@ namespace cbdc {
     auto operator<<(serializer& ser,
                     const parsec::runtime_locking_shard::shard_error& err)
         -> serializer&;
-    auto operator>>(serializer& deser,
-                    parsec::runtime_locking_shard::shard_error& err)
-        -> serializer&;
+    auto
+    operator>>(serializer& deser,
+               parsec::runtime_locking_shard::shard_error& err) -> serializer&;
 
     auto operator<<(serializer& ser,
                     const parsec::runtime_locking_shard::wounded_details& det)
@@ -90,10 +90,10 @@ namespace cbdc {
         parsec::runtime_locking_shard::rpc::replicated_get_tickets_request&
             req) -> serializer&;
 
-    auto operator<<(serializer& ser,
-                    const parsec::runtime_locking_shard::
-                        replicated_shard_interface::ticket_type& t)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const parsec::runtime_locking_shard::
+                   replicated_shard_interface::ticket_type& t) -> serializer&;
     auto operator>>(
         serializer& deser,
         parsec::runtime_locking_shard::replicated_shard_interface::ticket_type&

--- a/src/parsec/runtime_locking_shard/impl.hpp
+++ b/src/parsec/runtime_locking_shard/impl.hpp
@@ -142,23 +142,22 @@ namespace cbdc::parsec::runtime_locking_shard {
             m_state;
         std::unordered_map<ticket_number_type, ticket_state_type> m_tickets;
 
-        auto
-        wound_tickets(key_type key,
-                      const std::vector<ticket_number_type>& blocking_tickets,
-                      ticket_number_type blocked_ticket)
-            -> pending_callbacks_list_type;
+        auto wound_tickets(
+            key_type key,
+            const std::vector<ticket_number_type>& blocking_tickets,
+            ticket_number_type blocked_ticket) -> pending_callbacks_list_type;
 
-        static auto get_waiting_on(ticket_number_type ticket_number,
-                                   lock_type locktype,
-                                   rw_lock_type& lock)
-            -> std::vector<ticket_number_type>;
+        static auto
+        get_waiting_on(ticket_number_type ticket_number,
+                       lock_type locktype,
+                       rw_lock_type& lock) -> std::vector<ticket_number_type>;
 
         auto release_locks(ticket_number_type ticket_number,
                            ticket_state_type& ticket)
             -> std::pair<pending_callbacks_list_type, key_set_type>;
 
-        auto acquire_locks(const key_set_type& keys)
-            -> pending_callbacks_list_type;
+        auto
+        acquire_locks(const key_set_type& keys) -> pending_callbacks_list_type;
 
         auto acquire_lock(const key_type& key,
                           pending_callbacks_list_type& callbacks) -> bool;

--- a/src/parsec/runtime_locking_shard/interface.hpp
+++ b/src/parsec/runtime_locking_shard/interface.hpp
@@ -142,7 +142,7 @@ namespace cbdc::parsec::runtime_locking_shard {
                               lock_type locktype,
                               bool first_lock,
                               try_lock_callback_type result_callback) -> bool
-            = 0;
+                                                                         = 0;
 
         /// Return type from a prepare operation. An error, if applicable.
         using prepare_return_type = std::optional<shard_error>;
@@ -161,7 +161,7 @@ namespace cbdc::parsec::runtime_locking_shard {
                              broker_id_type broker_id,
                              state_update_type state_update,
                              prepare_callback_type result_callback) -> bool
-            = 0;
+                                                                       = 0;
 
         /// Return type from a commit operation. An error code, if applicable.
         using commit_return_type = std::optional<shard_error>;
@@ -175,8 +175,7 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \param result_callback function to call with the commit result.
         /// \return true if the operation was initiated successfully.
         virtual auto commit(ticket_number_type ticket_number,
-                            commit_callback_type result_callback) -> bool
-            = 0;
+                            commit_callback_type result_callback) -> bool = 0;
 
         /// Return type from a rollback operation. An error code, if
         /// applicable.
@@ -194,7 +193,7 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \return true if the operation was initiated successfully.
         virtual auto rollback(ticket_number_type ticket_number,
                               rollback_callback_type result_callback) -> bool
-            = 0;
+                                                                         = 0;
 
         /// Return type from a finish operation. An error code, if applicable.
         using finish_return_type = std::optional<shard_error>;
@@ -209,8 +208,7 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \param result_callback function to call with finish result.
         /// \return true if the operation was initiated successfully.
         virtual auto finish(ticket_number_type ticket_number,
-                            finish_callback_type result_callback) -> bool
-            = 0;
+                            finish_callback_type result_callback) -> bool = 0;
 
         /// Return type from a successful get tickets operation. A map of
         /// ticket numbers to their state.
@@ -228,10 +226,9 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \param broker_id broker ID.
         /// \param result_callback function to call with get tickets result.
         /// \return true if the operation was initiated successfully.
-        virtual auto get_tickets(broker_id_type broker_id,
-                                 get_tickets_callback_type result_callback)
-            -> bool
-            = 0;
+        virtual auto
+        get_tickets(broker_id_type broker_id,
+                    get_tickets_callback_type result_callback) -> bool = 0;
     };
 }
 

--- a/src/parsec/runtime_locking_shard/replicated_shard_client.cpp
+++ b/src/parsec/runtime_locking_shard/replicated_shard_client.cpp
@@ -15,11 +15,11 @@ namespace cbdc::parsec::runtime_locking_shard {
         std::shared_ptr<raft::node> raft_node)
         : m_raft(std::move(raft_node)) {}
 
-    auto replicated_shard_client::prepare(ticket_number_type ticket_number,
-                                          broker_id_type broker_id,
-                                          state_type state_update,
-                                          callback_type result_callback)
-        -> bool {
+    auto
+    replicated_shard_client::prepare(ticket_number_type ticket_number,
+                                     broker_id_type broker_id,
+                                     state_type state_update,
+                                     callback_type result_callback) -> bool {
         auto req = rpc::replicated_prepare_request{ticket_number,
                                                    broker_id,
                                                    std::move(state_update)};
@@ -41,9 +41,9 @@ namespace cbdc::parsec::runtime_locking_shard {
         return success;
     }
 
-    auto replicated_shard_client::commit(ticket_number_type ticket_number,
-                                         callback_type result_callback)
-        -> bool {
+    auto
+    replicated_shard_client::commit(ticket_number_type ticket_number,
+                                    callback_type result_callback) -> bool {
         auto req = rpc::commit_request{ticket_number};
         auto success = replicate_request(
             req,
@@ -63,9 +63,9 @@ namespace cbdc::parsec::runtime_locking_shard {
         return success;
     }
 
-    auto replicated_shard_client::finish(ticket_number_type ticket_number,
-                                         callback_type result_callback)
-        -> bool {
+    auto
+    replicated_shard_client::finish(ticket_number_type ticket_number,
+                                    callback_type result_callback) -> bool {
         auto req = rpc::finish_request{ticket_number};
         auto success = replicate_request(
             req,

--- a/src/parsec/runtime_locking_shard/replicated_shard_client.hpp
+++ b/src/parsec/runtime_locking_shard/replicated_shard_client.hpp
@@ -53,9 +53,8 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \param result_callback function to call with the tickets held by
         ///                        the state machine.
         /// \return true if request replication was initiated successfully.
-        [[nodiscard]] auto
-        get_tickets(get_tickets_callback_type result_callback) const
-            -> bool override;
+        [[nodiscard]] auto get_tickets(
+            get_tickets_callback_type result_callback) const -> bool override;
 
       private:
         std::shared_ptr<raft::node> m_raft;

--- a/src/parsec/runtime_locking_shard/replicated_shard_interface.hpp
+++ b/src/parsec/runtime_locking_shard/replicated_shard_interface.hpp
@@ -75,24 +75,21 @@ namespace cbdc::parsec::runtime_locking_shard {
         virtual auto prepare(ticket_number_type ticket_number,
                              broker_id_type broker_id,
                              state_type state_update,
-                             callback_type result_callback) -> bool
-            = 0;
+                             callback_type result_callback) -> bool = 0;
 
         /// Stores a commit request in the state machine.
         /// \param ticket_number ticket to commit.
         /// \param result_callback function to call with commit result.
         /// \return true if operation was initiated successfully.
         virtual auto commit(ticket_number_type ticket_number,
-                            callback_type result_callback) -> bool
-            = 0;
+                            callback_type result_callback) -> bool = 0;
 
         /// Stores a finish request in the state machine.
         /// \param ticket_number ticket to finish.
         /// \param result_callback function to call with finish result.
         /// \return true if operation was initiated successfully.
         virtual auto finish(ticket_number_type ticket_number,
-                            callback_type result_callback) -> bool
-            = 0;
+                            callback_type result_callback) -> bool = 0;
 
         /// Return type from a get tickets operation. Either a map of ticket
         /// states or an error code.
@@ -107,7 +104,7 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// \return true if operation was initiated successfully.
         [[nodiscard]] virtual auto
         get_tickets(get_tickets_callback_type result_callback) const -> bool
-            = 0;
+                                                                        = 0;
     };
 }
 

--- a/src/parsec/runtime_locking_shard/server.hpp
+++ b/src/parsec/runtime_locking_shard/server.hpp
@@ -35,8 +35,8 @@ namespace cbdc::parsec::runtime_locking_shard::rpc {
 
         using callback_type = std::function<void(std::optional<response>)>;
 
-        auto handler_callback(const request& req, callback_type callback)
-            -> bool;
+        auto handler_callback(const request& req,
+                              callback_type callback) -> bool;
 
         void handle_prepare(interface::prepare_return_type ret,
                             const rpc::prepare_request& msg,

--- a/src/parsec/runtime_locking_shard/state_machine.cpp
+++ b/src/parsec/runtime_locking_shard/state_machine.cpp
@@ -92,8 +92,8 @@ namespace cbdc::parsec::runtime_locking_shard {
         return ret;
     }
 
-    auto state_machine::get_shard() const
-        -> std::shared_ptr<replicated_shard> {
+    auto
+    state_machine::get_shard() const -> std::shared_ptr<replicated_shard> {
         return m_shard;
     }
 }

--- a/src/parsec/runtime_locking_shard/state_machine.hpp
+++ b/src/parsec/runtime_locking_shard/state_machine.hpp
@@ -46,8 +46,8 @@ namespace cbdc::parsec::runtime_locking_shard {
         /// Returns the replicated shard implementation managed by the state
         /// machine.
         /// \return pointer to the shard implementation.
-        [[nodiscard]] auto get_shard() const
-            -> std::shared_ptr<replicated_shard>;
+        [[nodiscard]] auto
+        get_shard() const -> std::shared_ptr<replicated_shard>;
 
       private:
         auto process_request(const rpc::replicated_request& req)

--- a/src/parsec/ticket_machine/client.cpp
+++ b/src/parsec/ticket_machine/client.cpp
@@ -10,15 +10,14 @@
 namespace cbdc::parsec::ticket_machine::rpc {
     client::client(std::vector<network::endpoint_t> endpoints)
         : m_client(std::make_unique<decltype(m_client)::element_type>(
-            std::move(endpoints))) {}
+              std::move(endpoints))) {}
 
     auto client::init() -> bool {
         return m_client->init();
     }
 
-    auto
-    client::get_ticket_number(get_ticket_number_callback_type result_callback)
-        -> bool {
+    auto client::get_ticket_number(
+        get_ticket_number_callback_type result_callback) -> bool {
         auto num = ticket_number_type{};
         {
             std::unique_lock l(m_mut);

--- a/src/parsec/ticket_machine/impl.cpp
+++ b/src/parsec/ticket_machine/impl.cpp
@@ -10,9 +10,8 @@ namespace cbdc::parsec::ticket_machine {
         : m_log(std::move(logger)),
           m_range(range) {}
 
-    auto
-    impl::get_ticket_number(get_ticket_number_callback_type result_callback)
-        -> bool {
+    auto impl::get_ticket_number(
+        get_ticket_number_callback_type result_callback) -> bool {
         auto ticket_number = m_next_ticket_number.fetch_add(m_range);
         result_callback(
             ticket_number_range_type{ticket_number, ticket_number + m_range});

--- a/src/parsec/ticket_machine/interface.hpp
+++ b/src/parsec/ticket_machine/interface.hpp
@@ -53,10 +53,8 @@ namespace cbdc::parsec::ticket_machine {
         /// to make this a very rare occurance.
         /// \param result_callback function to call with ticket number range.
         /// \return true if the request was initiated successfully.
-        virtual auto
-        get_ticket_number(get_ticket_number_callback_type result_callback)
-            -> bool
-            = 0;
+        virtual auto get_ticket_number(
+            get_ticket_number_callback_type result_callback) -> bool = 0;
     };
 }
 

--- a/src/parsec/ticket_machine/state_machine.cpp
+++ b/src/parsec/ticket_machine/state_machine.cpp
@@ -53,8 +53,8 @@ namespace cbdc::parsec::ticket_machine {
         when_done(ret, except);
     }
 
-    auto state_machine::process_request(rpc::request /* req */)
-        -> rpc::response {
+    auto
+    state_machine::process_request(rpc::request /* req */) -> rpc::response {
         auto ret = rpc::response();
         [[maybe_unused]] auto success = m_ticket_machine->get_ticket_number(
             [&](interface::get_ticket_number_return_type tkts) {

--- a/src/parsec/util.cpp
+++ b/src/parsec/util.cpp
@@ -9,8 +9,8 @@
 #include <unordered_map>
 
 namespace cbdc::parsec {
-    auto split(const std::string& s, const std::string& delim)
-        -> std::vector<std::string> {
+    auto split(const std::string& s,
+               const std::string& delim) -> std::vector<std::string> {
         size_t pos_start{};
         size_t pos_end{};
         std::vector<std::string> ret;

--- a/src/uhs/atomizer/archiver/client.hpp
+++ b/src/uhs/atomizer/archiver/client.hpp
@@ -37,8 +37,8 @@ namespace cbdc::archiver {
         /// Retrieves the block at the given height from the archiver.
         /// \param height height of the block to retrieve.
         /// \return block at the given height or std::nullopt if not found.
-        auto get_block(uint64_t height)
-            -> std::optional<cbdc::atomizer::block>;
+        auto
+        get_block(uint64_t height) -> std::optional<cbdc::atomizer::block>;
 
       private:
         network::tcp_socket m_sock;

--- a/src/uhs/atomizer/archiver/controller.hpp
+++ b/src/uhs/atomizer/archiver/controller.hpp
@@ -108,8 +108,8 @@ namespace cbdc::archiver {
         /// \param height the height of the block to retrieve.
         /// \return the block at the specified height, or std::nullopt if the
         ///         database does not contain a block at that height.
-        auto get_block(uint64_t height)
-            -> std::optional<cbdc::atomizer::block>;
+        auto
+        get_block(uint64_t height) -> std::optional<cbdc::atomizer::block>;
 
         /// \brief Returns true if this archiver is receiving blocks
         /// from the atomizer.

--- a/src/uhs/atomizer/atomizer/atomizer.hpp
+++ b/src/uhs/atomizer/atomizer/atomizer.hpp
@@ -91,9 +91,9 @@ namespace cbdc::atomizer {
         /// if there are no such errors.
         /// \return a pair containing the resultant block and errors to forward
         ///         to the watchtower if necessary.
-        [[nodiscard]] auto make_block()
-            -> std::pair<cbdc::atomizer::block,
-                         std::vector<watchtower::tx_error>>;
+        [[nodiscard]] auto
+        make_block() -> std::pair<cbdc::atomizer::block,
+                                  std::vector<watchtower::tx_error>>;
 
         /// Returns the number of complete transactions waiting to be
         /// included in the next block.
@@ -130,8 +130,8 @@ namespace cbdc::atomizer {
         uint64_t m_best_height{};
         size_t m_spent_cache_depth;
 
-        [[nodiscard]] auto get_notification_offset(uint64_t block_height) const
-            -> uint64_t;
+        [[nodiscard]] auto
+        get_notification_offset(uint64_t block_height) const -> uint64_t;
 
         [[nodiscard]] auto
         check_notification_offset(uint64_t height_offset,

--- a/src/uhs/atomizer/atomizer/atomizer_raft.cpp
+++ b/src/uhs/atomizer/atomizer/atomizer_raft.cpp
@@ -39,9 +39,9 @@ namespace cbdc::atomizer {
         return cls;
     }
 
-    auto atomizer_raft::make_request(const state_machine::request& r,
-                                     const raft::callback_type& result_fn)
-        -> bool {
+    auto
+    atomizer_raft::make_request(const state_machine::request& r,
+                                const raft::callback_type& result_fn) -> bool {
         auto new_log
             = make_buffer<state_machine::request, nuraft::ptr<nuraft::buffer>>(
                 r);

--- a/src/uhs/atomizer/atomizer/atomizer_raft.hpp
+++ b/src/uhs/atomizer/atomizer/atomizer_raft.hpp
@@ -79,8 +79,8 @@ namespace cbdc::atomizer {
         };
 
         struct attestation_cmp {
-            auto operator()(const attestation& a, const attestation& b) const
-                -> bool;
+            auto operator()(const attestation& a,
+                            const attestation& b) const -> bool;
         };
 
         using attestation_set = std::

--- a/src/uhs/atomizer/atomizer/format.cpp
+++ b/src/uhs/atomizer/atomizer/format.cpp
@@ -11,19 +11,19 @@
 #include "util/serialization/util.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const cbdc::atomizer::block& blk)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const cbdc::atomizer::block& blk) -> serializer& {
         return packet << blk.m_height << blk.m_transactions;
     }
 
-    auto operator>>(serializer& packet, cbdc::atomizer::block& blk)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    cbdc::atomizer::block& blk) -> serializer& {
         return packet >> blk.m_height >> blk.m_transactions;
     }
 
-    auto operator<<(serializer& ser,
-                    const atomizer::state_machine::snapshot& snp)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const atomizer::state_machine::snapshot& snp) -> serializer& {
         auto atomizer_buf = snp.m_atomizer->serialize();
         auto snp_buf = snp.m_snp->serialize();
         ser << static_cast<uint64_t>(snp_buf->size());
@@ -33,8 +33,8 @@ namespace cbdc {
         return ser;
     }
 
-    auto operator>>(serializer& deser, atomizer::state_machine::snapshot& snp)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    atomizer::state_machine::snapshot& snp) -> serializer& {
         uint64_t snp_sz{};
         deser >> snp_sz;
         auto snp_buf = nuraft::buffer::alloc(snp_sz);
@@ -47,15 +47,15 @@ namespace cbdc {
         return deser;
     }
 
-    auto operator<<(serializer& packet,
-                    const cbdc::atomizer::tx_notify_request& msg)
-        -> serializer& {
+    auto
+    operator<<(serializer& packet,
+               const cbdc::atomizer::tx_notify_request& msg) -> serializer& {
         packet << msg.m_block_height << msg.m_tx << msg.m_attestations;
         return packet;
     }
 
-    auto operator>>(serializer& packet, cbdc::atomizer::tx_notify_request& msg)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    cbdc::atomizer::tx_notify_request& msg) -> serializer& {
         packet >> msg.m_block_height >> msg.m_tx >> msg.m_attestations;
         return packet;
     }
@@ -67,9 +67,9 @@ namespace cbdc {
         return packet;
     }
 
-    auto operator>>(serializer& packet,
-                    cbdc::atomizer::aggregate_tx_notification& msg)
-        -> serializer& {
+    auto
+    operator>>(serializer& packet,
+               cbdc::atomizer::aggregate_tx_notification& msg) -> serializer& {
         packet >> msg.m_oldest_attestation >> msg.m_tx;
         return packet;
     }
@@ -86,49 +86,49 @@ namespace cbdc {
         return packet >> msg.m_agg_txs;
     }
 
-    auto operator<<(serializer& ser, const atomizer::prune_request& r)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const atomizer::prune_request& r) -> serializer& {
         return ser << r.m_block_height;
     }
-    auto operator>>(serializer& deser, atomizer::prune_request& r)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    atomizer::prune_request& r) -> serializer& {
+        return deser >> r.m_block_height;
+    }
+
+    auto
+    operator<<(serializer& ser,
+               const atomizer::make_block_request& /* r */) -> serializer& {
+        return ser;
+    }
+    auto operator>>(serializer& deser,
+                    atomizer::make_block_request& /* r */) -> serializer& {
+        return deser;
+    }
+
+    auto operator<<(serializer& ser,
+                    const atomizer::get_block_request& r) -> serializer& {
+        return ser << r.m_block_height;
+    }
+    auto operator>>(serializer& deser,
+                    atomizer::get_block_request& r) -> serializer& {
         return deser >> r.m_block_height;
     }
 
     auto operator<<(serializer& ser,
-                    const atomizer::make_block_request& /* r */)
-        -> serializer& {
-        return ser;
-    }
-    auto operator>>(serializer& deser, atomizer::make_block_request& /* r */)
-        -> serializer& {
-        return deser;
-    }
-
-    auto operator<<(serializer& ser, const atomizer::get_block_request& r)
-        -> serializer& {
-        return ser << r.m_block_height;
-    }
-    auto operator>>(serializer& deser, atomizer::get_block_request& r)
-        -> serializer& {
-        return deser >> r.m_block_height;
-    }
-
-    auto operator<<(serializer& ser, const atomizer::make_block_response& r)
-        -> serializer& {
+                    const atomizer::make_block_response& r) -> serializer& {
         return ser << r.m_blk << r.m_errs;
     }
-    auto operator>>(serializer& deser, atomizer::make_block_response& r)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    atomizer::make_block_response& r) -> serializer& {
         return deser >> r.m_blk >> r.m_errs;
     }
 
-    auto operator<<(serializer& ser, const atomizer::get_block_response& r)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const atomizer::get_block_response& r) -> serializer& {
         return ser << r.m_blk;
     }
-    auto operator>>(serializer& deser, atomizer::get_block_response& r)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    atomizer::get_block_response& r) -> serializer& {
         return deser >> r.m_blk;
     }
 }

--- a/src/uhs/atomizer/atomizer/format.hpp
+++ b/src/uhs/atomizer/atomizer/format.hpp
@@ -10,15 +10,15 @@
 #include "state_machine.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser,
-                    const atomizer::state_machine::snapshot& snp)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::state_machine::snapshot& snp)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const atomizer::state_machine::snapshot& snp) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::state_machine::snapshot& snp) -> serializer&;
 
-    auto operator<<(serializer& packet,
-                    const atomizer::aggregate_tx_notification& msg)
-        -> serializer&;
+    auto
+    operator<<(serializer& packet,
+               const atomizer::aggregate_tx_notification& msg) -> serializer&;
     auto operator>>(serializer& packet,
                     atomizer::aggregate_tx_notification& msg) -> serializer&;
 
@@ -28,40 +28,40 @@ namespace cbdc {
     auto operator>>(serializer& packet,
                     atomizer::aggregate_tx_notify_request& msg) -> serializer&;
 
-    auto operator<<(serializer& packet, const atomizer::tx_notify_request& msg)
-        -> serializer&;
-    auto operator>>(serializer& packet, atomizer::tx_notify_request& msg)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const atomizer::tx_notify_request& msg) -> serializer&;
+    auto operator>>(serializer& packet,
+                    atomizer::tx_notify_request& msg) -> serializer&;
 
-    auto operator<<(serializer& packet, const cbdc::atomizer::block& blk)
-        -> serializer&;
-    auto operator>>(serializer& packet, cbdc::atomizer::block& blk)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const cbdc::atomizer::block& blk) -> serializer&;
+    auto operator>>(serializer& packet,
+                    cbdc::atomizer::block& blk) -> serializer&;
 
-    auto operator<<(serializer& ser, const atomizer::prune_request& r)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::prune_request& r)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const atomizer::prune_request& r) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::prune_request& r) -> serializer&;
 
-    auto operator<<(serializer& ser, const atomizer::make_block_request& r)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::make_block_request& r)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const atomizer::make_block_request& r) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::make_block_request& r) -> serializer&;
 
-    auto operator<<(serializer& ser, const atomizer::get_block_request& r)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::get_block_request& r)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const atomizer::get_block_request& r) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::get_block_request& r) -> serializer&;
 
-    auto operator<<(serializer& ser, const atomizer::make_block_response& r)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::make_block_response& r)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const atomizer::make_block_response& r) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::make_block_response& r) -> serializer&;
 
-    auto operator<<(serializer& ser, const atomizer::get_block_response& r)
-        -> serializer&;
-    auto operator>>(serializer& deser, atomizer::get_block_response& r)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const atomizer::get_block_response& r) -> serializer&;
+    auto operator>>(serializer& deser,
+                    atomizer::get_block_response& r) -> serializer&;
 }
 
 #endif // OPENCBDC_TX_SRC_ATOMIZER_FORMAT_H_

--- a/src/uhs/atomizer/atomizer/messages.cpp
+++ b/src/uhs/atomizer/atomizer/messages.cpp
@@ -6,8 +6,8 @@
 #include "messages.hpp"
 
 namespace cbdc::atomizer {
-    auto tx_notify_request::operator==(const tx_notify_request& rhs) const
-        -> bool {
+    auto
+    tx_notify_request::operator==(const tx_notify_request& rhs) const -> bool {
         return (rhs.m_tx == m_tx) && (rhs.m_attestations == m_attestations)
             && (rhs.m_block_height == m_block_height);
     }

--- a/src/uhs/atomizer/atomizer/state_machine.cpp
+++ b/src/uhs/atomizer/atomizer/state_machine.cpp
@@ -275,8 +275,8 @@ namespace cbdc::atomizer {
         return m_snapshot_dir + "/" + m_tmp_file;
     }
 
-    auto state_machine::read_snapshot(uint64_t idx)
-        -> std::optional<snapshot> {
+    auto
+    state_machine::read_snapshot(uint64_t idx) -> std::optional<snapshot> {
         std::shared_lock<std::shared_mutex> l(m_snp_mut);
         auto open_fail_fatal = false;
         if(idx == 0) {

--- a/src/uhs/atomizer/atomizer/state_machine.hpp
+++ b/src/uhs/atomizer/atomizer/state_machine.hpp
@@ -89,13 +89,13 @@ namespace cbdc::atomizer {
         /// the snapshot referenced by the given snapshot metadata.
         /// \param s snapshot metadata.
         /// \return true if the operation successfully applied the snapshot.
-        [[nodiscard]] auto apply_snapshot(nuraft::snapshot& s)
-            -> bool override;
+        [[nodiscard]] auto
+        apply_snapshot(nuraft::snapshot& s) -> bool override;
 
         /// Returns the most recent snapshot metadata.
         /// \return snapshot metadata, or nullptr if there is no snapshot.
-        [[nodiscard]] auto last_snapshot()
-            -> nuraft::ptr<nuraft::snapshot> override;
+        [[nodiscard]] auto
+        last_snapshot() -> nuraft::ptr<nuraft::snapshot> override;
 
         /// Returns the index of the most recently committed log entry.
         /// \return log index.
@@ -130,13 +130,13 @@ namespace cbdc::atomizer {
         };
 
       private:
-        [[nodiscard]] auto get_snapshot_path(uint64_t idx) const
-            -> std::string;
+        [[nodiscard]] auto
+        get_snapshot_path(uint64_t idx) const -> std::string;
 
         [[nodiscard]] auto get_tmp_path() const -> std::string;
 
-        [[nodiscard]] auto read_snapshot(uint64_t idx)
-            -> std::optional<snapshot>;
+        [[nodiscard]] auto
+        read_snapshot(uint64_t idx) -> std::optional<snapshot>;
 
         static constexpr auto m_tmp_file = "tmp";
 

--- a/src/uhs/atomizer/shard/shard.cpp
+++ b/src/uhs/atomizer/shard/shard.cpp
@@ -11,8 +11,8 @@ namespace cbdc::shard {
     shard::shard(config::shard_range_t prefix_range)
         : m_prefix_range(std::move(prefix_range)) {}
 
-    auto shard::open_db(const std::string& db_dir)
-        -> std::optional<std::string> {
+    auto
+    shard::open_db(const std::string& db_dir) -> std::optional<std::string> {
         leveldb::Options opt;
         opt.create_if_missing = true;
 

--- a/src/uhs/atomizer/shard/shard.hpp
+++ b/src/uhs/atomizer/shard/shard.hpp
@@ -66,8 +66,8 @@ namespace cbdc::shard {
         [[nodiscard]] auto best_block_height() const -> uint64_t;
 
       private:
-        [[nodiscard]] auto is_output_on_shard(const hash_t& uhs_hash) const
-            -> bool;
+        [[nodiscard]] auto
+        is_output_on_shard(const hash_t& uhs_hash) const -> bool;
 
         void update_snapshot();
 

--- a/src/uhs/atomizer/watchtower/error_cache.hpp
+++ b/src/uhs/atomizer/watchtower/error_cache.hpp
@@ -44,8 +44,8 @@ namespace cbdc::watchtower {
         /// Checks the cache for an error associated with the given UHS ID.
         /// \param uhs_id the UHS ID to check.
         /// \return error information, or nullopt if not found.
-        auto check_uhs_id(const hash_t& uhs_id) const
-            -> std::optional<tx_error>;
+        auto
+        check_uhs_id(const hash_t& uhs_id) const -> std::optional<tx_error>;
 
       private:
         size_t m_k_errs;

--- a/src/uhs/atomizer/watchtower/messages.cpp
+++ b/src/uhs/atomizer/watchtower/messages.cpp
@@ -22,15 +22,15 @@ namespace cbdc {
         return packet >> bbh_res.m_height;
     }
 
-    auto operator<<(cbdc::serializer& packet,
-                    const cbdc::watchtower::request& req)
-        -> cbdc::serializer& {
+    auto
+    operator<<(cbdc::serializer& packet,
+               const cbdc::watchtower::request& req) -> cbdc::serializer& {
         return packet << req.m_req;
     }
 
-    auto operator<<(cbdc::serializer& packet,
-                    const cbdc::watchtower::response& res)
-        -> cbdc::serializer& {
+    auto
+    operator<<(cbdc::serializer& packet,
+               const cbdc::watchtower::response& res) -> cbdc::serializer& {
         return packet << res.m_resp;
     }
 }

--- a/src/uhs/atomizer/watchtower/messages.hpp
+++ b/src/uhs/atomizer/watchtower/messages.hpp
@@ -27,9 +27,9 @@ namespace cbdc {
     auto operator>>(cbdc::serializer& packet,
                     cbdc::watchtower::best_block_height_response& bbh_res)
         -> cbdc::serializer&;
-    auto operator<<(cbdc::serializer& packet,
-                    const cbdc::watchtower::response& res)
-        -> cbdc::serializer&;
+    auto
+    operator<<(cbdc::serializer& packet,
+               const cbdc::watchtower::response& res) -> cbdc::serializer&;
     auto operator<<(cbdc::serializer& packet,
                     const cbdc::watchtower::request& req) -> cbdc::serializer&;
 }

--- a/src/uhs/atomizer/watchtower/status_update.cpp
+++ b/src/uhs/atomizer/watchtower/status_update.cpp
@@ -14,9 +14,8 @@ namespace cbdc::watchtower {
         return m_uhs_ids;
     }
 
-    auto
-    status_update_request::operator==(const status_update_request& rhs) const
-        -> bool {
+    auto status_update_request::operator==(
+        const status_update_request& rhs) const -> bool {
         return rhs.m_uhs_ids == m_uhs_ids;
     }
 

--- a/src/uhs/atomizer/watchtower/status_update.hpp
+++ b/src/uhs/atomizer/watchtower/status_update.hpp
@@ -54,9 +54,9 @@ namespace cbdc::watchtower {
         cbdc::operator<<(cbdc::serializer& packet,
                          const cbdc::watchtower::status_update_request& su_req)
             -> cbdc::serializer&;
-        friend auto cbdc::operator>>(cbdc::serializer& packet,
-                                     status_update_request& su_req)
-            -> cbdc::serializer&;
+        friend auto
+        cbdc::operator>>(cbdc::serializer& packet,
+                         status_update_request& su_req) -> cbdc::serializer&;
 
         auto operator==(const status_update_request& rhs) const -> bool;
 
@@ -87,10 +87,9 @@ namespace cbdc::watchtower {
         cbdc::operator<<(cbdc::serializer& packet,
                          const cbdc::watchtower::status_update_state& state)
             -> cbdc::serializer&;
-        friend auto
-        cbdc::operator>>(cbdc::serializer& packet,
-                         cbdc::watchtower::status_update_state& state)
-            -> cbdc::serializer&;
+        friend auto cbdc::operator>>(
+            cbdc::serializer& packet,
+            cbdc::watchtower::status_update_state& state) -> cbdc::serializer&;
         friend class status_request_check_success;
 
         auto operator==(const status_update_state& rhs) const -> bool;

--- a/src/uhs/atomizer/watchtower/tx_error_messages.cpp
+++ b/src/uhs/atomizer/watchtower/tx_error_messages.cpp
@@ -13,8 +13,8 @@ namespace cbdc::watchtower {
         pkt >> *this;
     }
 
-    auto tx_error_sync::operator==(const tx_error_sync& /* rhs */) const
-        -> bool {
+    auto
+    tx_error_sync::operator==(const tx_error_sync& /* rhs */) const -> bool {
         return true;
     }
 
@@ -38,9 +38,8 @@ namespace cbdc::watchtower {
         pkt >> *this;
     }
 
-    auto
-    tx_error_stxo_range::operator==(const tx_error_stxo_range& /* rhs */) const
-        -> bool {
+    auto tx_error_stxo_range::operator==(
+        const tx_error_stxo_range& /* rhs */) const -> bool {
         return true;
     }
 
@@ -48,9 +47,8 @@ namespace cbdc::watchtower {
         pkt >> *this;
     }
 
-    auto
-    tx_error_incomplete::operator==(const tx_error_incomplete& /* rhs */) const
-        -> bool {
+    auto tx_error_incomplete::operator==(
+        const tx_error_incomplete& /* rhs */) const -> bool {
         return true;
     }
 
@@ -67,9 +65,8 @@ namespace cbdc::watchtower {
         std::unordered_set<hash_t, hashing::null> input_uhs_ids)
         : m_input_uhs_ids(std::move(input_uhs_ids)) {}
 
-    auto
-    tx_error_inputs_spent::operator==(const tx_error_inputs_spent& rhs) const
-        -> bool {
+    auto tx_error_inputs_spent::operator==(
+        const tx_error_inputs_spent& rhs) const -> bool {
         return rhs.m_input_uhs_ids == m_input_uhs_ids;
     }
 
@@ -164,14 +161,14 @@ namespace cbdc {
         return packet;
     }
 
-    auto operator<<(cbdc::serializer& packet,
-                    const cbdc::watchtower::tx_error& err)
-        -> cbdc::serializer& {
+    auto
+    operator<<(cbdc::serializer& packet,
+               const cbdc::watchtower::tx_error& err) -> cbdc::serializer& {
         return packet << err.m_tx_id << *err.m_info;
     }
 
-    auto operator>>(cbdc::serializer& packet, cbdc::watchtower::tx_error& err)
-        -> cbdc::serializer& {
+    auto operator>>(cbdc::serializer& packet,
+                    cbdc::watchtower::tx_error& err) -> cbdc::serializer& {
         packet >> err.m_tx_id;
         err.m_info = std::make_shared<decltype(err.m_info)::element_type>(
             get_variant<watchtower::tx_error_sync,

--- a/src/uhs/atomizer/watchtower/tx_error_messages.hpp
+++ b/src/uhs/atomizer/watchtower/tx_error_messages.hpp
@@ -51,11 +51,11 @@ namespace cbdc {
     auto operator>>(cbdc::serializer& packet,
                     cbdc::watchtower::tx_error_inputs_spent& err)
         -> cbdc::serializer&;
-    auto operator<<(cbdc::serializer& packet,
-                    const cbdc::watchtower::tx_error& err)
-        -> cbdc::serializer&;
-    auto operator>>(cbdc::serializer& packet, cbdc::watchtower::tx_error& err)
-        -> cbdc::serializer&;
+    auto
+    operator<<(cbdc::serializer& packet,
+               const cbdc::watchtower::tx_error& err) -> cbdc::serializer&;
+    auto operator>>(cbdc::serializer& packet,
+                    cbdc::watchtower::tx_error& err) -> cbdc::serializer&;
 }
 
 namespace cbdc::watchtower {
@@ -79,10 +79,9 @@ namespace cbdc::watchtower {
         cbdc::operator<<(cbdc::serializer& packet,
                          const cbdc::watchtower::tx_error_inputs_dne& err)
             -> cbdc::serializer&;
-        friend auto
-        cbdc::operator>>(cbdc::serializer& packet,
-                         cbdc::watchtower::tx_error_inputs_dne& err)
-            -> cbdc::serializer&;
+        friend auto cbdc::operator>>(
+            cbdc::serializer& packet,
+            cbdc::watchtower::tx_error_inputs_dne& err) -> cbdc::serializer&;
 
         auto operator==(const tx_error_inputs_dne& rhs) const -> bool;
 
@@ -137,10 +136,9 @@ namespace cbdc::watchtower {
         cbdc::operator<<(cbdc::serializer& packet,
                          const cbdc::watchtower::tx_error_inputs_spent& err)
             -> cbdc::serializer&;
-        friend auto
-        cbdc::operator>>(cbdc::serializer& packet,
-                         cbdc::watchtower::tx_error_inputs_spent& err)
-            -> cbdc::serializer&;
+        friend auto cbdc::operator>>(
+            cbdc::serializer& packet,
+            cbdc::watchtower::tx_error_inputs_spent& err) -> cbdc::serializer&;
 
         auto operator==(const tx_error_inputs_spent& rhs) const -> bool;
 
@@ -157,8 +155,8 @@ namespace cbdc::watchtower {
 
         /// Returns the UHS IDs of the inputs that caused this error.
         /// \return input UHS ID set.
-        [[nodiscard]] auto input_uhs_ids() const
-            -> std::unordered_set<hash_t, hashing::null>;
+        [[nodiscard]] auto
+        input_uhs_ids() const -> std::unordered_set<hash_t, hashing::null>;
 
       private:
         std::unordered_set<hash_t, hashing::null> m_input_uhs_ids;
@@ -170,9 +168,9 @@ namespace cbdc::watchtower {
         friend auto cbdc::operator<<(cbdc::serializer& packet,
                                      const cbdc::watchtower::tx_error& err)
             -> cbdc::serializer&;
-        friend auto cbdc::operator>>(cbdc::serializer& packet,
-                                     cbdc::watchtower::tx_error& err)
-            -> cbdc::serializer&;
+        friend auto
+        cbdc::operator>>(cbdc::serializer& packet,
+                         cbdc::watchtower::tx_error& err) -> cbdc::serializer&;
 
         auto operator==(const tx_error& rhs) const -> bool;
 

--- a/src/uhs/atomizer/watchtower/watchtower.cpp
+++ b/src/uhs/atomizer/watchtower/watchtower.cpp
@@ -116,9 +116,8 @@ namespace cbdc::watchtower {
         return states;
     }
 
-    auto
-    watchtower::handle_status_update_request(const status_update_request& req)
-        -> std::unique_ptr<response> {
+    auto watchtower::handle_status_update_request(
+        const status_update_request& req) -> std::unique_ptr<response> {
         std::unordered_map<hash_t,
                            std::vector<status_update_state>,
                            hashing::const_sip_hash<hash_t>>
@@ -195,7 +194,7 @@ namespace cbdc::watchtower {
 
     request::request(serializer& pkt)
         : m_req(get_variant<status_update_request, best_block_height_request>(
-            pkt)) {}
+              pkt)) {}
 
     auto request::payload() const -> const request_t& {
         return m_req;

--- a/src/uhs/atomizer/watchtower/watchtower.hpp
+++ b/src/uhs/atomizer/watchtower/watchtower.hpp
@@ -166,9 +166,8 @@ namespace cbdc::watchtower {
         /// Composes a response to a status update best block height request.
         /// \param req a best block height request from a client.
         /// \return the response to send to the client or nullopt if request is invalid.
-        auto
-        handle_best_block_height_request(const best_block_height_request& req)
-            -> std::unique_ptr<response>;
+        auto handle_best_block_height_request(
+            const best_block_height_request& req) -> std::unique_ptr<response>;
 
       private:
         block_cache m_bc;

--- a/src/uhs/client/atomizer_client.hpp
+++ b/src/uhs/client/atomizer_client.hpp
@@ -55,8 +55,8 @@ namespace cbdc {
         /// Sends the given transaction directly to the atomizer cluster.
         /// \param mint_tx transaction to send.
         /// \return true if sending the transaction was successful.
-        auto send_mint_tx(const transaction::full_tx& mint_tx)
-            -> bool override;
+        auto
+        send_mint_tx(const transaction::full_tx& mint_tx) -> bool override;
 
       private:
         cbdc::network::connection_manager m_atomizer_network;

--- a/src/uhs/client/client-cli.cpp
+++ b/src/uhs/client/client-cli.cpp
@@ -16,8 +16,8 @@
 #include <future>
 #include <iostream>
 
-auto mint_command(cbdc::client& client, const std::vector<std::string>& args)
-    -> bool {
+auto mint_command(cbdc::client& client,
+                  const std::vector<std::string>& args) -> bool {
     static constexpr auto min_mint_arg_count = 7;
     if(args.size() < min_mint_arg_count) {
         std::cerr << "Mint requires args <n outputs> <output value>"
@@ -62,8 +62,8 @@ void print_tx_result(
     }
 }
 
-auto send_command(cbdc::client& client, const std::vector<std::string>& args)
-    -> bool {
+auto send_command(cbdc::client& client,
+                  const std::vector<std::string>& args) -> bool {
     static constexpr auto min_send_arg_count = 7;
     if(args.size() < min_send_arg_count) {
         std::cerr << "Send requires args <value> <pubkey>" << std::endl;
@@ -89,8 +89,8 @@ auto send_command(cbdc::client& client, const std::vector<std::string>& args)
     return true;
 }
 
-auto fan_command(cbdc::client& client, const std::vector<std::string>& args)
-    -> bool {
+auto fan_command(cbdc::client& client,
+                 const std::vector<std::string>& args) -> bool {
     static constexpr auto min_fan_arg_count = 8;
     if(args.size() < min_fan_arg_count) {
         std::cerr << "Fan requires args <count> <value> <pubkey>" << std::endl;

--- a/src/uhs/client/client.cpp
+++ b/src/uhs/client/client.cpp
@@ -24,8 +24,8 @@
 namespace cbdc {
 
     namespace address {
-        auto decode(const std::string& addr_str)
-            -> std::optional<cbdc::hash_t> {
+        auto
+        decode(const std::string& addr_str) -> std::optional<cbdc::hash_t> {
             // TODO: if/when bech32m is merged into Bitcoin Core, switch to
             // that.
             //       see: https://github.com/bitcoin/bitcoin/pull/20861
@@ -92,8 +92,8 @@ namespace cbdc {
         return ss.str();
     }
 
-    auto client::mint(size_t n_outputs, uint32_t output_val)
-        -> transaction::full_tx {
+    auto client::mint(size_t n_outputs,
+                      uint32_t output_val) -> transaction::full_tx {
         auto mint_tx = m_wallet.mint_new_coins(n_outputs, output_val);
         import_transaction(mint_tx);
 

--- a/src/uhs/client/client.hpp
+++ b/src/uhs/client/client.hpp
@@ -15,8 +15,8 @@ namespace cbdc {
         static constexpr auto bits_per_byte = 8;
         static constexpr auto bech32_bits_per_symbol = 5;
 
-        auto decode(const std::string& addr_str)
-            -> std::optional<cbdc::hash_t>;
+        auto
+        decode(const std::string& addr_str) -> std::optional<cbdc::hash_t>;
     }
 
     /// External client for sending new transactions to the system.
@@ -66,8 +66,8 @@ namespace cbdc {
         /// \param n_outputs number of new spendable outputs to create.
         /// \param output_val value of the amount to associate with each output in the base unit of the currency.
         /// \return the completed transaction.
-        auto mint(size_t n_outputs, uint32_t output_val)
-            -> transaction::full_tx;
+        auto mint(size_t n_outputs,
+                  uint32_t output_val) -> transaction::full_tx;
 
         /// \brief Send a specified amount from this client's wallet to a
         ///        target address.
@@ -250,7 +250,7 @@ namespace cbdc {
         /// \param mint_tx invalid transaction that mints new coins.
         /// \return true if the transaction was sent successfully.
         virtual auto send_mint_tx(const transaction::full_tx& mint_tx) -> bool
-            = 0;
+                                                                          = 0;
 
         /// \brief Returns the set of transactions pending confirmation.
         ///

--- a/src/uhs/client/twophase_client.cpp
+++ b/src/uhs/client/twophase_client.cpp
@@ -63,8 +63,8 @@ namespace cbdc {
         return success;
     }
 
-    auto twophase_client::check_tx_id(const hash_t& tx_id)
-        -> std::optional<bool> {
+    auto
+    twophase_client::check_tx_id(const hash_t& tx_id) -> std::optional<bool> {
         return m_shard_status_client.check_tx_id(tx_id);
     }
 

--- a/src/uhs/client/twophase_client.hpp
+++ b/src/uhs/client/twophase_client.hpp
@@ -73,8 +73,8 @@ namespace cbdc {
         /// Sends the given mint transaction directly to a coordinator cluster.
         /// \param mint_tx transaction to send.
         /// \return true if the transaction was sent successfully.
-        auto send_mint_tx(const transaction::full_tx& mint_tx)
-            -> bool override;
+        auto
+        send_mint_tx(const transaction::full_tx& mint_tx) -> bool override;
 
       private:
         coordinator::rpc::client m_coordinator_client;

--- a/src/uhs/sentinel/async_interface.hpp
+++ b/src/uhs/sentinel/async_interface.hpp
@@ -39,11 +39,9 @@ namespace cbdc::sentinel {
         /// \param result_callback function to call with execution result.
         /// \return false if the implementation could not start processing the
         ///         transaction.
-        virtual auto
-        execute_transaction(transaction::full_tx tx,
-                            execute_result_callback_type result_callback)
-            -> bool
-            = 0;
+        virtual auto execute_transaction(
+            transaction::full_tx tx,
+            execute_result_callback_type result_callback) -> bool = 0;
 
         /// Result of a validation operation. Sentinel attestation for the
         /// given transaction or std::nullopt if the transaction was invalid.
@@ -59,11 +57,9 @@ namespace cbdc::sentinel {
         /// \param result_callback function to call with the validation result.
         /// \return false if the implementation could not start validating the
         ///         transaction.
-        virtual auto
-        validate_transaction(transaction::full_tx tx,
-                             validate_result_callback_type result_callback)
-            -> bool
-            = 0;
+        virtual auto validate_transaction(
+            transaction::full_tx tx,
+            validate_result_callback_type result_callback) -> bool = 0;
     };
 }
 

--- a/src/uhs/sentinel/client.hpp
+++ b/src/uhs/sentinel/client.hpp
@@ -52,10 +52,9 @@ namespace cbdc::sentinel::rpc {
         /// \param tx transaction to send to the sentinel.
         /// \param result_callback callback function to call with the result.
         /// \return true if the request was sent successfully.
-        auto execute_transaction(
-            transaction::full_tx tx,
-            std::function<void(execute_result_type)> result_callback)
-            -> bool override;
+        auto execute_transaction(transaction::full_tx tx,
+                                 std::function<void(execute_result_type)>
+                                     result_callback) -> bool override;
 
         /// Return type from transaction validation.
         using validate_result_type = std::optional<validate_response>;
@@ -73,10 +72,9 @@ namespace cbdc::sentinel::rpc {
         /// \param tx transaction to validate and attest to.
         /// \param result_callback callback function to call with the result.
         /// \return true if the request was sent successfully.
-        auto validate_transaction(
-            transaction::full_tx tx,
-            std::function<void(validate_result_type)> result_callback)
-            -> bool override;
+        auto validate_transaction(transaction::full_tx tx,
+                                  std::function<void(validate_result_type)>
+                                      result_callback) -> bool override;
 
       private:
         cbdc::config::options m_opts;

--- a/src/uhs/sentinel/format.cpp
+++ b/src/uhs/sentinel/format.cpp
@@ -9,13 +9,13 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const sentinel::execute_response& r)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const sentinel::execute_response& r) -> serializer& {
         return packet << r.m_tx_status << r.m_tx_error;
     }
 
-    auto operator>>(serializer& packet, sentinel::execute_response& r)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    sentinel::execute_response& r) -> serializer& {
         return packet >> r.m_tx_status >> r.m_tx_error;
     }
 }

--- a/src/uhs/sentinel/format.hpp
+++ b/src/uhs/sentinel/format.hpp
@@ -9,10 +9,10 @@
 #include "interface.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const sentinel::execute_response& r)
-        -> serializer&;
-    auto operator>>(serializer& packet, sentinel::execute_response& r)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const sentinel::execute_response& r) -> serializer&;
+    auto operator>>(serializer& packet,
+                    sentinel::execute_response& r) -> serializer&;
 }
 
 #endif // OPENCBDC_TX_SRC_SENTINEL_FORMAT_H_

--- a/src/uhs/transaction/messages.cpp
+++ b/src/uhs/transaction/messages.cpp
@@ -10,54 +10,54 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const transaction::out_point& op)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const transaction::out_point& op) -> serializer& {
         return packet << op.m_tx_id << op.m_index;
     }
 
-    auto operator>>(serializer& packet, transaction::out_point& op)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    transaction::out_point& op) -> serializer& {
         return packet >> op.m_tx_id >> op.m_index;
     }
 
-    auto operator<<(serializer& packet, const transaction::output& out)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const transaction::output& out) -> serializer& {
         return packet << out.m_witness_program_commitment << out.m_value;
     }
 
-    auto operator>>(serializer& packet, transaction::output& out)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    transaction::output& out) -> serializer& {
         return packet >> out.m_witness_program_commitment >> out.m_value;
     }
 
-    auto operator<<(serializer& packet, const transaction::input& inp)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const transaction::input& inp) -> serializer& {
         return packet << inp.m_prevout << inp.m_prevout_data;
     }
 
-    auto operator>>(serializer& packet, transaction::input& inp)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    transaction::input& inp) -> serializer& {
         return packet >> inp.m_prevout >> inp.m_prevout_data;
     }
 
-    auto operator<<(serializer& packet, const transaction::full_tx& tx)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const transaction::full_tx& tx) -> serializer& {
         return packet << tx.m_inputs << tx.m_outputs << tx.m_witness;
     }
 
-    auto operator>>(serializer& packet, transaction::full_tx& tx)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    transaction::full_tx& tx) -> serializer& {
         return packet >> tx.m_inputs >> tx.m_outputs >> tx.m_witness;
     }
 
-    auto operator<<(serializer& packet, const transaction::compact_tx& tx)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const transaction::compact_tx& tx) -> serializer& {
         return packet << tx.m_id << tx.m_inputs << tx.m_uhs_outputs
                       << tx.m_attestations;
     }
 
-    auto operator>>(serializer& packet, transaction::compact_tx& tx)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    transaction::compact_tx& tx) -> serializer& {
         return packet >> tx.m_id >> tx.m_inputs >> tx.m_uhs_outputs
             >> tx.m_attestations;
     }
@@ -67,9 +67,9 @@ namespace cbdc {
         return packet >> e.m_code >> e.m_data_err >> e.m_idx;
     }
 
-    auto operator<<(serializer& packet,
-                    const transaction::validation::input_error& e)
-        -> serializer& {
+    auto
+    operator<<(serializer& packet,
+               const transaction::validation::input_error& e) -> serializer& {
         return packet << e.m_code << e.m_data_err << e.m_idx;
     }
 
@@ -78,9 +78,9 @@ namespace cbdc {
         return packet >> e.m_code >> e.m_idx;
     }
 
-    auto operator<<(serializer& packet,
-                    const transaction::validation::output_error& e)
-        -> serializer& {
+    auto
+    operator<<(serializer& packet,
+               const transaction::validation::output_error& e) -> serializer& {
         return packet << e.m_code << e.m_idx;
     }
 

--- a/src/uhs/transaction/messages.hpp
+++ b/src/uhs/transaction/messages.hpp
@@ -17,39 +17,39 @@ namespace cbdc {
     /// identified output in that transaction's output vector.
     /// \see \ref cbdc::operator<<(serializer&, const std::array<T, len>&)
     /// \see \ref cbdc::operator<<(serializer&, T)
-    auto operator<<(serializer& packet, const transaction::out_point& op)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const transaction::out_point& op) -> serializer&;
 
     /// Deserializes an out_point.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::out_point&)
-    auto operator>>(serializer& packet, transaction::out_point& op)
-        -> serializer&;
+    auto operator>>(serializer& packet,
+                    transaction::out_point& op) -> serializer&;
 
     /// \brief Serializes an output.
     ///
     /// Serializes the witness program commitment, and then the value.
     /// \see \ref cbdc::operator<<(serializer&, const std::array<T, len>&)
     /// \see \ref cbdc::operator<<(serializer&, T)
-    auto operator<<(serializer& packet, const transaction::output& out)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const transaction::output& out) -> serializer&;
 
     /// Deserializes an output.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::output&)
-    auto operator>>(serializer& packet, transaction::output& out)
-        -> serializer&;
+    auto operator>>(serializer& packet,
+                    transaction::output& out) -> serializer&;
 
     /// \brief Serializes an input.
     ///
     /// Serializes the out_point and then the output.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::out_point&)
     /// \see \ref cbdc::operator<<(serializer&, const transaction::output&)
-    auto operator<<(serializer& packet, const transaction::input& inp)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const transaction::input& inp) -> serializer&;
 
     /// Deserializes an input.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::input&)
-    auto operator>>(serializer& packet, transaction::input& inp)
-        -> serializer&;
+    auto operator>>(serializer& packet,
+                    transaction::input& inp) -> serializer&;
 
     /// \brief Serializes a full transaction.
     ///
@@ -58,13 +58,13 @@ namespace cbdc {
     /// \see \ref cbdc::operator<<(serializer&, const transaction::input&)
     /// \see \ref cbdc::operator<<(serializer&, const transaction::output&)
     /// \see \ref cbdc::operator<<(serializer&, const std::byte)
-    auto operator<<(serializer& packet, const transaction::full_tx& tx)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const transaction::full_tx& tx) -> serializer&;
 
     /// Deserializes a full transaction.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::full_tx&)
-    auto operator>>(serializer& packet, transaction::full_tx& tx)
-        -> serializer&;
+    auto operator>>(serializer& packet,
+                    transaction::full_tx& tx) -> serializer&;
 
     /// \brief Serializes a compact transaction.
     ///
@@ -72,13 +72,13 @@ namespace cbdc {
     /// and then the output hashes.
     /// \see \ref cbdc::operator<<(serializer&, const std::array<T, len>&)
     /// \see \ref cbdc::operator<<(serializer&, const std::vector<T>&)
-    auto operator<<(serializer& packet, const transaction::compact_tx& tx)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const transaction::compact_tx& tx) -> serializer&;
 
     /// Deserializes a compact transaction.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::compact_tx&)
-    auto operator>>(serializer& packet, transaction::compact_tx& tx)
-        -> serializer&;
+    auto operator>>(serializer& packet,
+                    transaction::compact_tx& tx) -> serializer&;
 
     /// Deserializes an input error.
     /// \see \ref cbdc::operator<<(serializer&,
@@ -92,9 +92,9 @@ namespace cbdc {
     /// input's index.
     /// \see \ref cbdc::operator<<(serializer&, T)
     /// \see \ref cbdc::operator<<(serializer&, const std::optional<T>&)
-    auto operator<<(serializer& packet,
-                    const transaction::validation::input_error& e)
-        -> serializer&;
+    auto
+    operator<<(serializer& packet,
+               const transaction::validation::input_error& e) -> serializer&;
 
     /// Deserializes an output error.
     /// \see \ref cbdc::operator<<(serializer&,
@@ -106,9 +106,9 @@ namespace cbdc {
     ///
     /// Serializes the error code and then the output's index.
     /// \see \ref cbdc::operator<<(serializer&, T)
-    auto operator<<(serializer& packet,
-                    const transaction::validation::output_error& e)
-        -> serializer&;
+    auto
+    operator<<(serializer& packet,
+               const transaction::validation::output_error& e) -> serializer&;
 
     /// Deserializes a witness error.
     /// \see \ref cbdc::operator<<(serializer&,
@@ -120,9 +120,9 @@ namespace cbdc {
     ///
     /// Serializes the error code and then the witness's index.
     /// \see \ref cbdc::operator<<(serializer&, T)
-    auto operator<<(serializer& packet,
-                    const transaction::validation::witness_error& e)
-        -> serializer&;
+    auto
+    operator<<(serializer& packet,
+               const transaction::validation::witness_error& e) -> serializer&;
 }
 
 #endif // OPENCBDC_TX_SRC_TRANSACTION_MESSAGES_H_

--- a/src/uhs/transaction/transaction.cpp
+++ b/src/uhs/transaction/transaction.cpp
@@ -84,8 +84,9 @@ namespace cbdc::transaction {
         return ret;
     }
 
-    auto input_from_output(const full_tx& tx, size_t i, const hash_t& txid)
-        -> std::optional<input> {
+    auto input_from_output(const full_tx& tx,
+                           size_t i,
+                           const hash_t& txid) -> std::optional<input> {
         input ret;
         if(i >= tx.m_outputs.size()) {
             return std::nullopt;
@@ -96,8 +97,8 @@ namespace cbdc::transaction {
         return ret;
     }
 
-    auto input_from_output(const full_tx& tx, size_t i)
-        -> std::optional<input> {
+    auto input_from_output(const full_tx& tx,
+                           size_t i) -> std::optional<input> {
         const auto id = tx_id(tx);
         return input_from_output(tx, i, id);
     }
@@ -134,8 +135,8 @@ namespace cbdc::transaction {
         }
     }
 
-    auto compact_tx::sign(secp256k1_context* ctx, const privkey_t& key) const
-        -> sentinel_attestation {
+    auto compact_tx::sign(secp256k1_context* ctx,
+                          const privkey_t& key) const -> sentinel_attestation {
         auto payload = hash();
         auto pubkey = pubkey_from_privkey(key, ctx);
         secp256k1_keypair keypair{};

--- a/src/uhs/transaction/transaction.hpp
+++ b/src/uhs/transaction/transaction.hpp
@@ -143,9 +143,9 @@ namespace cbdc::transaction {
         /// \param key private key with which to sign the transaction.
         /// \return sentinel attestation containing the signature and
         ///         associated public key.
-        [[nodiscard]] auto sign(secp256k1_context* ctx,
-                                const privkey_t& key) const
-            -> sentinel_attestation;
+        [[nodiscard]] auto
+        sign(secp256k1_context* ctx,
+             const privkey_t& key) const -> sentinel_attestation;
 
         /// Verify the given attestation contains a valid signature that
         /// matches the compact transaction.
@@ -154,9 +154,9 @@ namespace cbdc::transaction {
         ///            signature.
         /// \return true if the given attestation is valid for this compact
         ///         transaction.
-        [[nodiscard]] auto verify(secp256k1_context* ctx,
-                                  const sentinel_attestation& att) const
-            -> bool;
+        [[nodiscard]] auto
+        verify(secp256k1_context* ctx,
+               const sentinel_attestation& att) const -> bool;
 
         /// Return the hash of the compact transaction, without the sentinel
         /// attestations included. Used as the message which is signed in
@@ -185,15 +185,16 @@ namespace cbdc::transaction {
     /// \param i index of the target output
     /// \param txid the txid of the transaction
     /// \return resultant input, or std::nullopt if i is invalid.
-    auto input_from_output(const full_tx& tx, size_t i, const hash_t& txid)
-        -> std::optional<input>;
+    auto input_from_output(const full_tx& tx,
+                           size_t i,
+                           const hash_t& txid) -> std::optional<input>;
 
     /// Calls input_from_output after calculating the TXID
     /// \param tx the transaction from which to read outputs
     /// \param i index of the target output
     /// \return result of input_from_output(tx, i, tx_id(tx))
-    auto input_from_output(const full_tx& tx, size_t i)
-        -> std::optional<input>;
+    auto input_from_output(const full_tx& tx,
+                           size_t i) -> std::optional<input>;
 
     auto uhs_id_from_output(const hash_t& entropy,
                             uint64_t i,

--- a/src/uhs/transaction/validation.cpp
+++ b/src/uhs/transaction/validation.cpp
@@ -33,8 +33,8 @@ namespace cbdc::transaction::validation {
         return std::tie(m_code, m_idx) == std::tie(rhs.m_code, rhs.m_idx);
     }
 
-    auto check_tx(const cbdc::transaction::full_tx& tx)
-        -> std::optional<tx_error> {
+    auto
+    check_tx(const cbdc::transaction::full_tx& tx) -> std::optional<tx_error> {
         const auto structure_err = check_tx_structure(tx);
         if(structure_err) {
             return structure_err;
@@ -135,8 +135,8 @@ namespace cbdc::transaction::validation {
 
     // TODO: check input assumptions with flags for whether preconditions have
     //       already been checked.
-    auto check_witness(const cbdc::transaction::full_tx& tx, size_t idx)
-        -> std::optional<witness_error_code> {
+    auto check_witness(const cbdc::transaction::full_tx& tx,
+                       size_t idx) -> std::optional<witness_error_code> {
         const auto& witness_program = tx.m_witness[idx];
         if(witness_program.empty()) {
             return witness_error_code::missing_witness_program_type;
@@ -155,8 +155,8 @@ namespace cbdc::transaction::validation {
         }
     }
 
-    auto check_p2pk_witness(const cbdc::transaction::full_tx& tx, size_t idx)
-        -> std::optional<witness_error_code> {
+    auto check_p2pk_witness(const cbdc::transaction::full_tx& tx,
+                            size_t idx) -> std::optional<witness_error_code> {
         const auto witness_len_err = check_p2pk_witness_len(tx, idx);
         if(witness_len_err) {
             return witness_len_err;
@@ -176,9 +176,9 @@ namespace cbdc::transaction::validation {
         return std::nullopt;
     }
 
-    auto check_p2pk_witness_len(const cbdc::transaction::full_tx& tx,
-                                size_t idx)
-        -> std::optional<witness_error_code> {
+    auto
+    check_p2pk_witness_len(const cbdc::transaction::full_tx& tx,
+                           size_t idx) -> std::optional<witness_error_code> {
         const auto& wit = tx.m_witness[idx];
         if(wit.size() != p2pk_witness_len) {
             return witness_error_code::malformed;

--- a/src/uhs/transaction/validation.hpp
+++ b/src/uhs/transaction/validation.hpp
@@ -122,16 +122,17 @@ namespace cbdc::transaction::validation {
     auto check_tx(const transaction::full_tx& tx) -> std::optional<tx_error>;
     auto check_tx_structure(const transaction::full_tx& tx)
         -> std::optional<tx_error>;
-    auto check_input_structure(const transaction::input& inp) -> std::optional<
-        std::pair<input_error_code, std::optional<output_error_code>>>;
+    auto check_input_structure(const transaction::input& inp)
+        -> std::optional<
+            std::pair<input_error_code, std::optional<output_error_code>>>;
     auto check_in_out_set(const transaction::full_tx& tx)
         -> std::optional<tx_error>;
     // TODO: check input assumptions with flags for whether preconditions have
     //       already been checked.
-    auto check_witness(const transaction::full_tx& tx, size_t idx)
-        -> std::optional<witness_error_code>;
-    auto check_p2pk_witness(const transaction::full_tx& tx, size_t idx)
-        -> std::optional<witness_error_code>;
+    auto check_witness(const transaction::full_tx& tx,
+                       size_t idx) -> std::optional<witness_error_code>;
+    auto check_p2pk_witness(const transaction::full_tx& tx,
+                            size_t idx) -> std::optional<witness_error_code>;
     auto check_p2pk_witness_len(const transaction::full_tx& tx, size_t idx)
         -> std::optional<witness_error_code>;
     auto check_p2pk_witness_commitment(const transaction::full_tx& tx,
@@ -146,8 +147,8 @@ namespace cbdc::transaction::validation {
         -> std::optional<tx_error>;
     auto check_witness_count(const transaction::full_tx& tx)
         -> std::optional<tx_error>;
-    auto check_input_set(const transaction::full_tx& tx)
-        -> std::optional<tx_error>;
+    auto
+    check_input_set(const transaction::full_tx& tx) -> std::optional<tx_error>;
     auto check_output_value(const transaction::output& out)
         -> std::optional<output_error_code>;
     auto get_p2pk_witness_commitment(const pubkey_t& payee) -> hash_t;

--- a/src/uhs/transaction/wallet.hpp
+++ b/src/uhs/transaction/wallet.hpp
@@ -58,8 +58,9 @@ namespace cbdc::transaction {
         /// \param sign_tx true if the wallet should sign this transaction.
         /// \return the completed transaction.
         /// \see \ref export_send_inputs
-        auto send_to(uint32_t amount, const pubkey_t& payee, bool sign_tx)
-            -> std::optional<full_tx>;
+        auto send_to(uint32_t amount,
+                     const pubkey_t& payee,
+                     bool sign_tx) -> std::optional<full_tx>;
 
         /// \brief Generates a new send transaction with the specified number
         ///        of inputs and outputs.
@@ -113,9 +114,9 @@ namespace cbdc::transaction {
         /// \return inputs to transmit to the send transaction recipient, or
         ///         empty vector if there is no transaction output with the
         ///         corresponding payee information.
-        static auto export_send_inputs(const full_tx& send_tx,
-                                       const pubkey_t& payee)
-            -> std::vector<input>;
+        static auto
+        export_send_inputs(const full_tx& send_tx,
+                           const pubkey_t& payee) -> std::vector<input>;
 
         /// Generates a new public key at which this wallet can receive
         /// payments via \ref send_to.
@@ -203,8 +204,8 @@ namespace cbdc::transaction {
         /// \param seed_idx the index in the seed set for which to generate the
         ///                 transaction.
         /// \returns the generated transaction.
-        auto create_seeded_transaction(size_t seed_idx)
-            -> std::optional<full_tx>;
+        auto
+        create_seeded_transaction(size_t seed_idx) -> std::optional<full_tx>;
 
         /// Given a set of credit inputs, add the UTXOs and update the wallet's
         /// balance.

--- a/src/uhs/twophase/coordinator/client.cpp
+++ b/src/uhs/twophase/coordinator/client.cpp
@@ -10,7 +10,7 @@
 namespace cbdc::coordinator::rpc {
     client::client(std::vector<network::endpoint_t> endpoints)
         : m_client(std::make_unique<decltype(m_client)::element_type>(
-            std::move(endpoints))) {}
+              std::move(endpoints))) {}
 
     auto client::init() -> bool {
         return m_client->init();

--- a/src/uhs/twophase/coordinator/client.hpp
+++ b/src/uhs/twophase/coordinator/client.hpp
@@ -38,9 +38,9 @@ namespace cbdc::coordinator::rpc {
         ///                        available.
         /// \return true if the RPC request was sent to the cluster
         ///         successfully.
-        auto execute_transaction(transaction::compact_tx tx,
-                                 callback_type result_callback)
-            -> bool override;
+        auto
+        execute_transaction(transaction::compact_tx tx,
+                            callback_type result_callback) -> bool override;
 
       private:
         std::unique_ptr<cbdc::rpc::tcp_client<request, response>> m_client;

--- a/src/uhs/twophase/coordinator/controller.cpp
+++ b/src/uhs/twophase/coordinator/controller.cpp
@@ -143,10 +143,9 @@ namespace cbdc::coordinator {
         return nuraft::cb_func::ReturnCode::Ok;
     }
 
-    auto
-    controller::prepare_cb(const hash_t& dtx_id,
-                           const std::vector<transaction::compact_tx>& txs)
-        -> bool {
+    auto controller::prepare_cb(
+        const hash_t& dtx_id,
+        const std::vector<transaction::compact_tx>& txs) -> bool {
         // Send the prepare status for this dtx ID and the txs contained within
         // to the coordinator RSM and ensure it replicated (or failed) before
         // returning.
@@ -154,11 +153,10 @@ namespace cbdc::coordinator {
         return replicate_sm_command(comm).has_value();
     }
 
-    auto
-    controller::commit_cb(const hash_t& dtx_id,
-                          const std::vector<bool>& complete_txs,
-                          const std::vector<std::vector<uint64_t>>& tx_idxs)
-        -> bool {
+    auto controller::commit_cb(
+        const hash_t& dtx_id,
+        const std::vector<bool>& complete_txs,
+        const std::vector<std::vector<uint64_t>>& tx_idxs) -> bool {
         // Send the commit status for this dtx ID and the result from prepare,
         // along with the mapping of which txs are relevant to each shard in
         // the prepare result to the RSM and check if it replicated.
@@ -681,9 +679,9 @@ namespace cbdc::coordinator {
                         rhs.m_discard_txs);
     }
 
-    auto controller::execute_transaction(transaction::compact_tx tx,
-                                         callback_type result_callback)
-        -> bool {
+    auto
+    controller::execute_transaction(transaction::compact_tx tx,
+                                    callback_type result_callback) -> bool {
         // If we're not the leader we can't process txs
         if(!m_raft_serv->is_leader()) {
             return false;

--- a/src/uhs/twophase/coordinator/controller.hpp
+++ b/src/uhs/twophase/coordinator/controller.hpp
@@ -131,9 +131,9 @@ namespace cbdc::coordinator {
         ///         false if the current batch already contained the
         ///         transaction or if the controller shut down before the
         ///         operation could finish.
-        auto execute_transaction(transaction::compact_tx tx,
-                                 callback_type result_callback)
-            -> bool override;
+        auto
+        execute_transaction(transaction::compact_tx tx,
+                            callback_type result_callback) -> bool override;
 
       private:
         size_t m_node_id;
@@ -186,13 +186,13 @@ namespace cbdc::coordinator {
                            nuraft::cb_func::Param* param)
             -> nuraft::cb_func::ReturnCode;
 
-        auto prepare_cb(const hash_t& dtx_id,
-                        const std::vector<transaction::compact_tx>& txs)
-            -> bool;
-        auto commit_cb(const hash_t& dtx_id,
-                       const std::vector<bool>& complete_txs,
-                       const std::vector<std::vector<uint64_t>>& tx_idxs)
-            -> bool;
+        auto
+        prepare_cb(const hash_t& dtx_id,
+                   const std::vector<transaction::compact_tx>& txs) -> bool;
+        auto
+        commit_cb(const hash_t& dtx_id,
+                  const std::vector<bool>& complete_txs,
+                  const std::vector<std::vector<uint64_t>>& tx_idxs) -> bool;
         auto discard_cb(const hash_t& dtx_id) -> bool;
         auto done_cb(const hash_t& dtx_id) -> bool;
 

--- a/src/uhs/twophase/coordinator/distributed_tx.cpp
+++ b/src/uhs/twophase/coordinator/distributed_tx.cpp
@@ -69,8 +69,8 @@ namespace cbdc::coordinator {
         return ret;
     }
 
-    auto distributed_tx::commit(const std::vector<bool>& complete_txs)
-        -> bool {
+    auto
+    distributed_tx::commit(const std::vector<bool>& complete_txs) -> bool {
         if(m_commit_cb) {
             auto res = m_commit_cb(m_dtx_id, complete_txs, m_tx_idxs);
             if(!res) {

--- a/src/uhs/twophase/coordinator/distributed_tx.hpp
+++ b/src/uhs/twophase/coordinator/distributed_tx.hpp
@@ -147,8 +147,8 @@ namespace cbdc::coordinator {
       private:
         [[nodiscard]] auto prepare() -> std::optional<std::vector<bool>>;
 
-        [[nodiscard]] auto commit(const std::vector<bool>& complete_txs)
-            -> bool;
+        [[nodiscard]] auto
+        commit(const std::vector<bool>& complete_txs) -> bool;
 
         auto discard() -> bool;
 

--- a/src/uhs/twophase/coordinator/format.cpp
+++ b/src/uhs/twophase/coordinator/format.cpp
@@ -18,15 +18,15 @@ namespace cbdc {
         return ser << s.m_prepare_txs << s.m_commit_txs << s.m_discard_txs;
     }
 
-    auto operator>>(serializer& deser,
-                    coordinator::controller::coordinator_state& s)
-        -> serializer& {
+    auto
+    operator>>(serializer& deser,
+               coordinator::controller::coordinator_state& s) -> serializer& {
         return deser >> s.m_prepare_txs >> s.m_commit_txs >> s.m_discard_txs;
     }
 
-    auto operator<<(serializer& ser,
-                    const coordinator::controller::sm_command& c)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const coordinator::controller::sm_command& c) -> serializer& {
         ser << c.m_header;
         switch(c.m_header.m_comm) {
             case coordinator::state_machine::command::prepare: {
@@ -59,9 +59,9 @@ namespace cbdc {
         return ser << static_cast<uint8_t>(c.m_comm) << c.m_dtx_id;
     }
 
-    auto operator>>(serializer& deser,
-                    coordinator::controller::sm_command_header& c)
-        -> serializer& {
+    auto
+    operator>>(serializer& deser,
+               coordinator::controller::sm_command_header& c) -> serializer& {
         uint8_t comm{};
         deser >> comm;
         c.m_comm = static_cast<coordinator::state_machine::command>(comm);

--- a/src/uhs/twophase/coordinator/format.hpp
+++ b/src/uhs/twophase/coordinator/format.hpp
@@ -13,20 +13,20 @@ namespace cbdc {
     auto operator<<(serializer& ser,
                     const coordinator::state_machine::coordinator_state& s)
         -> serializer&;
-    auto operator>>(serializer& deser,
-                    coordinator::controller::coordinator_state& s)
-        -> serializer&;
+    auto
+    operator>>(serializer& deser,
+               coordinator::controller::coordinator_state& s) -> serializer&;
 
-    auto operator<<(serializer& ser,
-                    const coordinator::controller::sm_command& c)
-        -> serializer&;
+    auto
+    operator<<(serializer& ser,
+               const coordinator::controller::sm_command& c) -> serializer&;
 
     auto operator<<(serializer& ser,
                     const coordinator::controller::sm_command_header& c)
         -> serializer&;
-    auto operator>>(serializer& deser,
-                    coordinator::controller::sm_command_header& c)
-        -> serializer&;
+    auto
+    operator>>(serializer& deser,
+               coordinator::controller::sm_command_header& c) -> serializer&;
 }
 
 #endif // OPENCBDC_TX_SRC_COORDINATOR_FORMAT_H_

--- a/src/uhs/twophase/coordinator/interface.hpp
+++ b/src/uhs/twophase/coordinator/interface.hpp
@@ -40,7 +40,7 @@ namespace cbdc::coordinator {
         ///         transaction.
         virtual auto execute_transaction(transaction::compact_tx tx,
                                          callback_type result_callback) -> bool
-            = 0;
+                                                                           = 0;
     };
 }
 

--- a/src/uhs/twophase/locking_shard/format.cpp
+++ b/src/uhs/twophase/locking_shard/format.cpp
@@ -9,8 +9,8 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const locking_shard::tx& tx)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const locking_shard::tx& tx) -> serializer& {
         return packet << tx.m_tx;
     }
 
@@ -18,19 +18,19 @@ namespace cbdc {
         return packet >> tx.m_tx;
     }
 
-    auto operator<<(serializer& packet, const locking_shard::rpc::request& p)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const locking_shard::rpc::request& p) -> serializer& {
         return packet << p.m_dtx_id << p.m_params;
     }
 
-    auto operator>>(serializer& packet, locking_shard::rpc::request& p)
-        -> serializer& {
+    auto operator>>(serializer& packet,
+                    locking_shard::rpc::request& p) -> serializer& {
         return packet >> p.m_dtx_id >> p.m_params;
     }
 
-    auto operator<<(serializer& packet,
-                    const locking_shard::rpc::tx_status_request& p)
-        -> serializer& {
+    auto
+    operator<<(serializer& packet,
+               const locking_shard::rpc::tx_status_request& p) -> serializer& {
         return packet << p.m_tx_id;
     }
 

--- a/src/uhs/twophase/locking_shard/format.hpp
+++ b/src/uhs/twophase/locking_shard/format.hpp
@@ -10,24 +10,24 @@
 #include "status_client.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& packet, const locking_shard::tx& tx)
-        -> serializer&;
+    auto operator<<(serializer& packet,
+                    const locking_shard::tx& tx) -> serializer&;
     auto operator>>(serializer& packet, locking_shard::tx& tx) -> serializer&;
 
-    auto operator<<(serializer& packet, const locking_shard::rpc::request& p)
-        -> serializer&;
-    auto operator>>(serializer& packet, locking_shard::rpc::request& p)
-        -> serializer&;
-
     auto operator<<(serializer& packet,
-                    const locking_shard::rpc::tx_status_request& p)
-        -> serializer&;
+                    const locking_shard::rpc::request& p) -> serializer&;
+    auto operator>>(serializer& packet,
+                    locking_shard::rpc::request& p) -> serializer&;
+
+    auto
+    operator<<(serializer& packet,
+               const locking_shard::rpc::tx_status_request& p) -> serializer&;
     auto operator>>(serializer& packet,
                     locking_shard::rpc::tx_status_request& p) -> serializer&;
 
-    auto operator<<(serializer& packet,
-                    const locking_shard::rpc::uhs_status_request& p)
-        -> serializer&;
+    auto
+    operator<<(serializer& packet,
+               const locking_shard::rpc::uhs_status_request& p) -> serializer&;
     auto operator>>(serializer& packet,
                     locking_shard::rpc::uhs_status_request& p) -> serializer&;
 }

--- a/src/uhs/twophase/locking_shard/interface.hpp
+++ b/src/uhs/twophase/locking_shard/interface.hpp
@@ -63,14 +63,13 @@ namespace cbdc::locking_shard {
         ///               operation.
         /// \return true if the apply operation succeeded.
         virtual auto apply_outputs(std::vector<bool>&& complete_txs,
-                                   const hash_t& dtx_id) -> bool
-            = 0;
+                                   const hash_t& dtx_id) -> bool = 0;
 
         /// Returns whether a given hash is within the shard's range.
         /// \param h hash to check.
         /// \return true if the hash is within the shard's range.
-        [[nodiscard]] virtual auto hash_in_shard_range(const hash_t& h) const
-            -> bool;
+        [[nodiscard]] virtual auto
+        hash_in_shard_range(const hash_t& h) const -> bool;
 
         /// Discards any cached information about a given distributed
         /// transaction.

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -53,8 +53,8 @@ namespace cbdc::locking_shard {
         }
     }
 
-    auto locking_shard::read_preseed_file(const std::string& preseed_file)
-        -> bool {
+    auto
+    locking_shard::read_preseed_file(const std::string& preseed_file) -> bool {
         if(std::filesystem::exists(preseed_file)) {
             auto in = std::ifstream(preseed_file, std::ios::binary);
             in.seekg(0, std::ios::end);
@@ -185,15 +185,15 @@ namespace cbdc::locking_shard {
         m_running = false;
     }
 
-    auto locking_shard::check_unspent(const hash_t& uhs_id)
-        -> std::optional<bool> {
+    auto
+    locking_shard::check_unspent(const hash_t& uhs_id) -> std::optional<bool> {
         std::shared_lock<std::shared_mutex> l(m_mut);
         return m_uhs.find(uhs_id) != m_uhs.end()
             || m_locked.find(uhs_id) != m_locked.end();
     }
 
-    auto locking_shard::check_tx_id(const hash_t& tx_id)
-        -> std::optional<bool> {
+    auto
+    locking_shard::check_tx_id(const hash_t& tx_id) -> std::optional<bool> {
         return m_completed_txs.contains(tx_id);
     }
 }

--- a/src/uhs/twophase/locking_shard/locking_shard.hpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.hpp
@@ -113,16 +113,16 @@ namespace cbdc::locking_shard {
         /// \param uhs_id UHS ID to query.
         /// \return true if the UHS ID is unspent, false if not. std::nullopt
         ///         if the query failed.
-        [[nodiscard]] auto check_unspent(const hash_t& uhs_id)
-            -> std::optional<bool> final;
+        [[nodiscard]] auto
+        check_unspent(const hash_t& uhs_id) -> std::optional<bool> final;
 
         /// Queries whether the given TX ID is confirmed in the cache of
         /// recently confirmed TX IDs.
         /// \param tx_id TX ID to query.
         /// \return true if cache contains TX ID, or false if not. std::nullopt
         ///         if the query failed.
-        [[nodiscard]] auto check_tx_id(const hash_t& tx_id)
-            -> std::optional<bool> final;
+        [[nodiscard]] auto
+        check_tx_id(const hash_t& tx_id) -> std::optional<bool> final;
 
       private:
         auto read_preseed_file(const std::string& preseed_file) -> bool;

--- a/src/uhs/twophase/locking_shard/messages.hpp
+++ b/src/uhs/twophase/locking_shard/messages.hpp
@@ -17,8 +17,8 @@ namespace cbdc::locking_shard::rpc {
     using apply_params = std::vector<bool>;
     /// Empty type for discard command parameters
     struct discard_params {
-        constexpr auto operator==(const discard_params& /* rhs */) const
-            -> bool {
+        constexpr auto
+        operator==(const discard_params& /* rhs */) const -> bool {
             return true;
         };
     };
@@ -40,15 +40,15 @@ namespace cbdc::locking_shard::rpc {
     using lock_response = std::vector<bool>;
     /// Empty type for the apply response
     struct apply_response {
-        constexpr auto operator==(const apply_response& /* rhs */) const
-            -> bool {
+        constexpr auto
+        operator==(const apply_response& /* rhs */) const -> bool {
             return true;
         };
     };
     /// Empty type for the discard response
     struct discard_response {
-        constexpr auto operator==(const discard_response& /* rhs */) const
-            -> bool {
+        constexpr auto
+        operator==(const discard_response& /* rhs */) const -> bool {
             return true;
         };
     };

--- a/src/uhs/twophase/locking_shard/status_client.cpp
+++ b/src/uhs/twophase/locking_shard/status_client.cpp
@@ -34,13 +34,13 @@ namespace cbdc::locking_shard::rpc {
         return true;
     }
 
-    auto status_client::check_tx_id(const hash_t& tx_id)
-        -> std::optional<bool> {
+    auto
+    status_client::check_tx_id(const hash_t& tx_id) -> std::optional<bool> {
         return make_request<tx_status_request>(tx_id);
     }
 
-    auto status_client::check_unspent(const hash_t& uhs_id)
-        -> std::optional<bool> {
+    auto
+    status_client::check_unspent(const hash_t& uhs_id) -> std::optional<bool> {
         return make_request<uhs_status_request>(uhs_id);
     }
 }

--- a/src/uhs/twophase/locking_shard/status_client.hpp
+++ b/src/uhs/twophase/locking_shard/status_client.hpp
@@ -51,16 +51,16 @@ namespace cbdc::locking_shard::rpc {
         /// \param uhs_id UHS ID to query.
         /// \return true if the UHS ID is unspent, or std::nullopt if the request
         ///         failed.
-        [[nodiscard]] auto check_unspent(const hash_t& uhs_id)
-            -> std::optional<bool> override;
+        [[nodiscard]] auto
+        check_unspent(const hash_t& uhs_id) -> std::optional<bool> override;
 
         /// Queries the shard cluster responsible for the given TX ID for
         /// whether it is in the confirmed TX IDs cache.
         /// \param tx_id TX ID to query.
         /// \return true if the cache contains the TX ID, or std::nullopt if
         ///         the request failed.
-        [[nodiscard]] auto check_tx_id(const hash_t& tx_id)
-            -> std::optional<bool> override;
+        [[nodiscard]] auto
+        check_tx_id(const hash_t& tx_id) -> std::optional<bool> override;
 
       private:
         std::vector<std::unique_ptr<

--- a/src/uhs/twophase/locking_shard/status_interface.hpp
+++ b/src/uhs/twophase/locking_shard/status_interface.hpp
@@ -28,16 +28,16 @@ namespace cbdc::locking_shard {
         /// \param uhs_id UHS ID to query.
         /// \return true if the UHS ID is unspent, or std::nullopt if the query
         ///         failed.
-        [[nodiscard]] virtual auto check_unspent(const hash_t& uhs_id)
-            -> std::optional<bool> = 0;
+        [[nodiscard]] virtual auto
+        check_unspent(const hash_t& uhs_id) -> std::optional<bool> = 0;
 
         /// Queries whether the given TX ID is confirmed in the cache of
         /// recently confirmed TX IDs.
         /// \param tx_id TX ID to query.
         /// \return true if the TX ID is present in the cache, or std::nullopt
         ///         if the query failed.
-        [[nodiscard]] virtual auto check_tx_id(const hash_t& tx_id)
-            -> std::optional<bool> = 0;
+        [[nodiscard]] virtual auto
+        check_tx_id(const hash_t& tx_id) -> std::optional<bool> = 0;
     };
 }
 

--- a/src/uhs/twophase/locking_shard/status_server.hpp
+++ b/src/uhs/twophase/locking_shard/status_server.hpp
@@ -31,8 +31,8 @@ namespace cbdc::locking_shard::rpc {
             cbdc::rpc::blocking_server<status_request, status_response>>
             m_srv;
 
-        auto request_handler(status_request req)
-            -> std::optional<status_response>;
+        auto
+        request_handler(status_request req) -> std::optional<status_response>;
     };
 }
 

--- a/src/uhs/twophase/sentinel_2pc/controller.hpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.hpp
@@ -61,10 +61,9 @@ namespace cbdc::sentinel_2pc {
         /// \param result_callback function to call with the attestation or
         ///                        std::nullopt if the transaction was invalid.
         /// \return true.
-        auto
-        validate_transaction(transaction::full_tx tx,
-                             validate_result_callback_type result_callback)
-            -> bool override;
+        auto validate_transaction(
+            transaction::full_tx tx,
+            validate_result_callback_type result_callback) -> bool override;
 
       private:
         static void result_handler(std::optional<bool> res,

--- a/src/util/common/buffer.cpp
+++ b/src/util/common/buffer.cpp
@@ -74,8 +74,8 @@ namespace cbdc {
         return ret.str();
     }
 
-    auto buffer::to_hex_prefixed(const std::string& prefix) const
-        -> std::string {
+    auto
+    buffer::to_hex_prefixed(const std::string& prefix) const -> std::string {
         auto res = std::string();
         res.append(prefix);
         res.append(to_hex());

--- a/src/util/common/buffer.hpp
+++ b/src/util/common/buffer.hpp
@@ -64,8 +64,8 @@ namespace cbdc {
         /// Creates a new buffer from the provided hex string.
         /// \param hex string-encoded hex representation of this buffer.
         /// \return a new buffer.
-        static auto from_hex(const std::string& hex)
-            -> std::optional<cbdc::buffer>;
+        static auto
+        from_hex(const std::string& hex) -> std::optional<cbdc::buffer>;
 
         /// Returns a hex string representation of the contents of the buffer.
         /// \return a hex encoded string.
@@ -77,8 +77,8 @@ namespace cbdc {
         /// \param prefix text at start of hex string. Defaults to "0x".
         /// \return a new buffer.
         static auto from_hex_prefixed(const std::string& hex,
-                                      const std::string& prefix = "0x")
-            -> std::optional<buffer>;
+                                      const std::string& prefix
+                                      = "0x") -> std::optional<buffer>;
 
         /// Returns a hex string representation of the contents of the
         /// buffer prefixed with a prefix sequence

--- a/src/util/common/config.cpp
+++ b/src/util/common/config.cpp
@@ -137,16 +137,16 @@ namespace cbdc::config {
         ss << watchtower_prefix << watchtower_id << config_separator;
     }
 
-    auto get_watchtower_client_endpoint_key(size_t watchtower_id)
-        -> std::string {
+    auto
+    get_watchtower_client_endpoint_key(size_t watchtower_id) -> std::string {
         std::stringstream ss;
         get_watchtower_key_prefix(ss, watchtower_id);
         ss << watchtower_client_ep_postfix;
         return ss.str();
     }
 
-    auto get_watchtower_internal_endpoint_key(size_t watchtower_id)
-        -> std::string {
+    auto
+    get_watchtower_internal_endpoint_key(size_t watchtower_id) -> std::string {
         std::stringstream ss;
         get_watchtower_key_prefix(ss, watchtower_id);
         ss << watchtower_internal_ep_postfix;
@@ -167,24 +167,24 @@ namespace cbdc::config {
         return ss.str();
     }
 
-    auto get_shard_raft_endpoint_key(size_t shard_id, size_t node_id)
-        -> std::string {
+    auto get_shard_raft_endpoint_key(size_t shard_id,
+                                     size_t node_id) -> std::string {
         std::stringstream ss;
         get_shard_key_prefix(ss, shard_id);
         ss << node_id << config_separator << raft_endpoint_postfix;
         return ss.str();
     }
 
-    auto get_shard_endpoint_key(size_t shard_id, size_t node_id)
-        -> std::string {
+    auto get_shard_endpoint_key(size_t shard_id,
+                                size_t node_id) -> std::string {
         std::stringstream ss;
         get_shard_key_prefix(ss, shard_id);
         ss << node_id << config_separator << endpoint_postfix;
         return ss.str();
     }
 
-    auto get_shard_readonly_endpoint_key(size_t shard_id, size_t node_id)
-        -> std::string {
+    auto get_shard_readonly_endpoint_key(size_t shard_id,
+                                         size_t node_id) -> std::string {
         std::stringstream ss;
         get_shard_key_prefix(ss, shard_id);
         ss << node_id << config_separator << readonly << config_separator
@@ -197,8 +197,8 @@ namespace cbdc::config {
         ss << coordinator_prefix << coordinator_id << config_separator;
     }
 
-    auto get_coordinator_endpoint_key(size_t coordinator_id, size_t node_id)
-        -> std::string {
+    auto get_coordinator_endpoint_key(size_t coordinator_id,
+                                      size_t node_id) -> std::string {
         std::stringstream ss;
         get_coordinator_key_prefix(ss, coordinator_id);
         ss << node_id << config_separator << endpoint_postfix;
@@ -292,8 +292,8 @@ namespace cbdc::config {
         return std::nullopt;
     }
 
-    auto read_shard_options(options& opts, const parser& cfg)
-        -> std::optional<std::string> {
+    auto read_shard_options(options& opts,
+                            const parser& cfg) -> std::optional<std::string> {
         const auto shard_count = cfg.get_ulong(shard_count_key).value_or(0);
         for(size_t i{0}; i < shard_count; i++) {
             if(!opts.m_twophase_mode) {
@@ -733,13 +733,13 @@ namespace cbdc::config {
         return std::nullopt;
     }
 
-    auto hash_in_shard_range(const shard_range_t& range, const hash_t& val)
-        -> bool {
+    auto hash_in_shard_range(const shard_range_t& range,
+                             const hash_t& val) -> bool {
         return val[0] >= range.first && val[0] <= range.second;
     }
 
-    auto loadgen_seed_range(const options& opts, size_t gen_id)
-        -> std::pair<size_t, size_t> {
+    auto loadgen_seed_range(const options& opts,
+                            size_t gen_id) -> std::pair<size_t, size_t> {
         assert(gen_id < opts.m_loadgen_count);
         auto total_seed_range = opts.m_seed_to - opts.m_seed_from;
         auto seed_range_sz = total_seed_range / opts.m_loadgen_count;
@@ -792,8 +792,8 @@ namespace cbdc::config {
         return get_val<std::string>(key);
     }
 
-    auto parser::get_ulong(const std::string& key) const
-        -> std::optional<size_t> {
+    auto
+    parser::get_ulong(const std::string& key) const -> std::optional<size_t> {
         return get_val<size_t>(key);
     }
 

--- a/src/util/common/config.hpp
+++ b/src/util/common/config.hpp
@@ -285,8 +285,8 @@ namespace cbdc::config {
     /// \param range shard hash prefix range.
     /// \param val hash to check.
     /// \return true if the hash prefix is within the inclusive range.
-    auto hash_in_shard_range(const shard_range_t& range, const hash_t& val)
-        -> bool;
+    auto hash_in_shard_range(const shard_range_t& range,
+                             const hash_t& val) -> bool;
 
     /// Calculates the sub-range of total seeded outputs for a particular load
     /// generator ID.
@@ -294,8 +294,8 @@ namespace cbdc::config {
     /// \param gen_id ID of load generator for which to calculate the
     ///               sub-range. Must be less than the load generator count.
     /// \return pair representing start and end of the seed range.
-    auto loadgen_seed_range(const options& opts, size_t gen_id)
-        -> std::pair<size_t, size_t>;
+    auto loadgen_seed_range(const options& opts,
+                            size_t gen_id) -> std::pair<size_t, size_t>;
 
     /// Converts c-args from an executable's main function into a vector of
     /// strings.
@@ -334,15 +334,15 @@ namespace cbdc::config {
         /// \param key key to retrieve.
         /// \return value associated with the key or std::nullopt if the value
         ///         was not a string or does not exist.
-        [[nodiscard]] auto get_string(const std::string& key) const
-            -> std::optional<std::string>;
+        [[nodiscard]] auto
+        get_string(const std::string& key) const -> std::optional<std::string>;
 
         /// Return the value for the given key if its value is a long.
         /// \param key key to retrieve.
         /// \return value associated with the key, or std::nullopt if the value
         ///         was not a long or doesn't exist.
-        [[nodiscard]] auto get_ulong(const std::string& key) const
-            -> std::optional<size_t>;
+        [[nodiscard]] auto
+        get_ulong(const std::string& key) const -> std::optional<size_t>;
 
         /// Return the value for the given key if its value is an endpoint.
         /// \param key key to retrieve.
@@ -362,18 +362,18 @@ namespace cbdc::config {
         /// \param key key to retrieve.
         /// \return value associated with the key, or std::nullopt if the value
         ///         was not a double or does not exist.
-        [[nodiscard]] auto get_decimal(const std::string& key) const
-            -> std::optional<double>;
+        [[nodiscard]] auto
+        get_decimal(const std::string& key) const -> std::optional<double>;
 
       private:
         using value_t = std::variant<std::string, size_t, double>;
 
-        [[nodiscard]] auto find_or_env(const std::string& key) const
-            -> std::optional<value_t>;
+        [[nodiscard]] auto
+        find_or_env(const std::string& key) const -> std::optional<value_t>;
 
         template<typename T>
-        [[nodiscard]] auto get_val(const std::string& key) const
-            -> std::optional<T> {
+        [[nodiscard]] auto
+        get_val(const std::string& key) const -> std::optional<T> {
             const auto it = find_or_env(key);
             if(it) {
                 const auto* val = std::get_if<T>(&it.value());
@@ -387,8 +387,8 @@ namespace cbdc::config {
 
         void init(std::istream& stream);
 
-        [[nodiscard]] static auto parse_value(const std::string& val)
-            -> value_t;
+        [[nodiscard]] static auto
+        parse_value(const std::string& val) -> value_t;
 
         std::map<std::string, value_t> m_options;
     };

--- a/src/util/common/keys.cpp
+++ b/src/util/common/keys.cpp
@@ -9,8 +9,8 @@
 #include <secp256k1_schnorrsig.h>
 
 namespace cbdc {
-    auto pubkey_from_privkey(const privkey_t& privkey, secp256k1_context* ctx)
-        -> pubkey_t {
+    auto pubkey_from_privkey(const privkey_t& privkey,
+                             secp256k1_context* ctx) -> pubkey_t {
         secp256k1_keypair keypair{};
         [[maybe_unused]] const auto create_ret
             = ::secp256k1_keypair_create(ctx, &keypair, privkey.data());

--- a/src/util/common/keys.hpp
+++ b/src/util/common/keys.hpp
@@ -32,8 +32,8 @@ namespace cbdc {
     /// \param privkey private key for which to generate the public key.
     /// \param ctx the secp context to use.
     /// \return the public key.
-    auto pubkey_from_privkey(const privkey_t& privkey, secp256k1_context* ctx)
-        -> pubkey_t;
+    auto pubkey_from_privkey(const privkey_t& privkey,
+                             secp256k1_context* ctx) -> pubkey_t;
 
     /// Converts an std::array into an std::vector of the same size via copy.
     /// \param arr the array to convert.

--- a/src/util/network/connection_manager.hpp
+++ b/src/util/network/connection_manager.hpp
@@ -55,8 +55,8 @@ namespace cbdc::network {
         connection_manager() = default;
 
         connection_manager(const connection_manager&) = delete;
-        auto operator=(const connection_manager&)
-            -> connection_manager& = delete;
+        auto
+        operator=(const connection_manager&) -> connection_manager& = delete;
 
         connection_manager(connection_manager&&) = delete;
         auto operator=(connection_manager&&) -> connection_manager& = delete;
@@ -68,8 +68,8 @@ namespace cbdc::network {
         /// \param port port to use.
         /// \return true if creating the listener succeeded. False if port or IP is
         /// unavailable.
-        [[nodiscard]] auto listen(const ip_address& host, unsigned short port)
-            -> bool;
+        [[nodiscard]] auto listen(const ip_address& host,
+                                  unsigned short port) -> bool;
 
         /// Listens for and accepts inbound connections.
         /// \return true on a clean shutdown. False upon a socket accept failure.
@@ -117,10 +117,9 @@ namespace cbdc::network {
         /// \return the thread on which the handler will be called, or nullopt if any client connection fails. May be joined by callers.
         /// \note Calling this method and start_server on the same connection_manager
         ///       instance will result in two handler threads.
-        [[nodiscard]] auto
-        start_cluster_handler(const std::vector<endpoint_t>& endpoints,
-                              const packet_handler_t& handler)
-            -> std::optional<std::thread>;
+        [[nodiscard]] auto start_cluster_handler(
+            const std::vector<endpoint_t>& endpoints,
+            const packet_handler_t& handler) -> std::optional<std::thread>;
 
         /// Establishes a server at the specified endpoint which handles
         /// inbound traffic with the specified handler function.
@@ -143,8 +142,8 @@ namespace cbdc::network {
         /// using the specified handler function.
         /// \param handler function to handle packets from client connections.
         /// \return the thread on which the handler will be called.
-        [[nodiscard]] auto start_handler(const packet_handler_t& handler)
-            -> std::thread;
+        [[nodiscard]] auto
+        start_handler(const packet_handler_t& handler) -> std::thread;
 
         /// Shuts down the network listener and all existing peer connections.
         void close();
@@ -176,8 +175,8 @@ namespace cbdc::network {
         /// Send the provided data to an online peer managed by this network.
         /// \param data packet to send.
         /// \return flag to indicate whether the packet was sent to a peer.
-        [[nodiscard]] auto send_to_one(const std::shared_ptr<buffer>& data)
-            -> bool;
+        [[nodiscard]] auto
+        send_to_one(const std::shared_ptr<buffer>& data) -> bool;
 
         /// Serialize and send the provided data to an online peer managed by
         /// this network. Wraps connection_manager::send_to_one.

--- a/src/util/network/tcp_listener.hpp
+++ b/src/util/network/tcp_listener.hpp
@@ -26,8 +26,8 @@ namespace cbdc::network {
         /// \param local_address the address of the interface to listen on
         /// \param local_port the port number to listen on
         /// \return true if the listener started listening successfully.
-        auto listen(const ip_address& local_address, port_number_t local_port)
-            -> bool;
+        auto listen(const ip_address& local_address,
+                    port_number_t local_port) -> bool;
 
         /// Blocks until an incoming connection is ready and
         /// populates the given socket.

--- a/src/util/raft/index_comparator.hpp
+++ b/src/util/raft/index_comparator.hpp
@@ -17,9 +17,9 @@ namespace cbdc::raft {
         /// \param a first key.
         /// \param b second key.
         /// \return 0 if a == b. -1 if a < b. 1 if a > b.
-        [[nodiscard]] auto Compare(const leveldb::Slice& a,
-                                   const leveldb::Slice& b) const
-            -> int override;
+        [[nodiscard]] auto
+        Compare(const leveldb::Slice& a,
+                const leveldb::Slice& b) const -> int override;
 
         /// Return the comparator name.
         /// \return "IndexComparator".

--- a/src/util/raft/log_store.cpp
+++ b/src/util/raft/log_store.cpp
@@ -160,8 +160,8 @@ namespace cbdc::raft {
         }
     }
 
-    auto log_store::log_entries(uint64_t start, uint64_t end)
-        -> log_entries_t {
+    auto log_store::log_entries(uint64_t start,
+                                uint64_t end) -> log_entries_t {
         const auto first_key = get_key_slice(start);
         auto ret = nuraft::cs_new<log_entries_t::element_type>(end - start);
 
@@ -187,8 +187,8 @@ namespace cbdc::raft {
         return ret;
     }
 
-    auto log_store::entry_at(uint64_t index)
-        -> nuraft::ptr<nuraft::log_entry> {
+    auto
+    log_store::entry_at(uint64_t index) -> nuraft::ptr<nuraft::log_entry> {
         const auto key = get_key_slice(index);
         std::string val;
 
@@ -213,8 +213,8 @@ namespace cbdc::raft {
         return entry->get_term();
     }
 
-    auto log_store::pack(uint64_t index, int32_t cnt)
-        -> nuraft::ptr<nuraft::buffer> {
+    auto log_store::pack(uint64_t index,
+                         int32_t cnt) -> nuraft::ptr<nuraft::buffer> {
         assert(cnt >= 0);
         const auto entries
             = log_entries(index, index + static_cast<uint64_t>(cnt));

--- a/src/util/raft/log_store.hpp
+++ b/src/util/raft/log_store.hpp
@@ -41,14 +41,14 @@ namespace cbdc::raft {
         /// Return the last log entry in the log store. Returns an empty log
         /// entry at index zero if the log store is empty.
         /// \return log entry.
-        [[nodiscard]] auto last_entry() const
-            -> nuraft::ptr<nuraft::log_entry> override;
+        [[nodiscard]] auto
+        last_entry() const -> nuraft::ptr<nuraft::log_entry> override;
 
         /// Append the given log entry to the end of the log.
         /// \param entry log entry to append.
         /// \return index of the appended log entry.
-        auto append(nuraft::ptr<nuraft::log_entry>& entry)
-            -> uint64_t override;
+        auto
+        append(nuraft::ptr<nuraft::log_entry>& entry) -> uint64_t override;
 
         /// Write a log entry at the given index.
         /// \param index log index at which to write the entry.
@@ -64,15 +64,15 @@ namespace cbdc::raft {
         /// \param start first log entry to retrieve.
         /// \param end last log entry to retrieve (exclusive).
         /// \return list of log entries.
-        [[nodiscard]] auto log_entries(uint64_t start, uint64_t end)
-            -> log_entries_t override;
+        [[nodiscard]] auto log_entries(uint64_t start,
+                                       uint64_t end) -> log_entries_t override;
 
         /// Return the log entry at the given index. Returns a null log entry
         /// if there is no log entry at the given index.
         /// \param index log index.
         /// \return log entry.
-        [[nodiscard]] auto entry_at(uint64_t index)
-            -> nuraft::ptr<nuraft::log_entry> override;
+        [[nodiscard]] auto
+        entry_at(uint64_t index) -> nuraft::ptr<nuraft::log_entry> override;
 
         /// Return the log term associated with the log entry at the given
         /// index.

--- a/src/util/raft/messages.cpp
+++ b/src/util/raft/messages.cpp
@@ -6,8 +6,8 @@
 #include "messages.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser, const nuraft::ptr<nuraft::buffer>& buf)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const nuraft::ptr<nuraft::buffer>& buf) -> serializer& {
         ser.write(buf->data_begin(), buf->size());
         return ser;
     }

--- a/src/util/raft/messages.hpp
+++ b/src/util/raft/messages.hpp
@@ -11,8 +11,8 @@
 #include <libnuraft/buffer.hxx>
 
 namespace cbdc {
-    auto operator<<(serializer& ser, const nuraft::ptr<nuraft::buffer>& buf)
-        -> serializer&;
+    auto operator<<(serializer& ser,
+                    const nuraft::ptr<nuraft::buffer>& buf) -> serializer&;
 }
 
 #endif // OPENCBDC_TX_SRC_RAFT_MESSAGES_H_

--- a/src/util/raft/node.hpp
+++ b/src/util/raft/node.hpp
@@ -78,9 +78,9 @@ namespace cbdc::raft {
         /// \param result_fn callback function to call asynchronously with the
         ///                  state machine execution result.
         /// \return true if the log entry was accepted for replication.
-        [[nodiscard]] auto replicate(nuraft::ptr<nuraft::buffer> new_log,
-                                     const callback_type& result_fn) const
-            -> bool;
+        [[nodiscard]] auto
+        replicate(nuraft::ptr<nuraft::buffer> new_log,
+                  const callback_type& result_fn) const -> bool;
 
         /// Replicates the provided log entry and returns the results from the
         /// state machine if the replication was successful. The method will

--- a/src/util/raft/rpc_server.hpp
+++ b/src/util/raft/rpc_server.hpp
@@ -37,9 +37,9 @@ namespace cbdc::raft::rpc {
         using response_callback_type =
             typename cbdc::rpc::raw_async_server::response_callback_type;
 
-        auto request_handler(buffer request_buf,
-                             response_callback_type response_callback)
-            -> bool {
+        auto
+        request_handler(buffer request_buf,
+                        response_callback_type response_callback) -> bool {
             if(!m_impl->is_leader()) {
                 return false;
             }

--- a/src/util/rpc/async_server.hpp
+++ b/src/util/rpc/async_server.hpp
@@ -127,9 +127,8 @@ namespace cbdc::rpc {
 
         using server_type = server<Request, Response, InBuffer, OutBuffer>;
 
-        static constexpr auto raw_mode
-            = std::is_same_v<Request,
-                             buffer> && std::is_same_v<Response, buffer>;
+        static constexpr auto raw_mode = std::is_same_v<Request, buffer>
+                                      && std::is_same_v<Response, buffer>;
     };
 
     /// \brief Asynchronous pass-through RPC server.

--- a/src/util/rpc/blocking_server.hpp
+++ b/src/util/rpc/blocking_server.hpp
@@ -27,8 +27,8 @@ namespace cbdc::rpc {
       public:
         blocking_server() = default;
         blocking_server(blocking_server&&) noexcept = default;
-        auto operator=(blocking_server&&) noexcept
-            -> blocking_server& = default;
+        auto
+        operator=(blocking_server&&) noexcept -> blocking_server& = default;
         blocking_server(const blocking_server&) = default;
         auto operator=(const blocking_server&) -> blocking_server& = default;
 

--- a/src/util/rpc/client.hpp
+++ b/src/util/rpc/client.hpp
@@ -50,10 +50,10 @@ namespace cbdc::rpc {
         ///                call should not timeout.
         /// \return response from the RPC, or std::nullopt if the call timed out
         ///         or produced an error.
-        [[nodiscard]] auto call(Request request_payload,
-                                std::chrono::milliseconds timeout
-                                = std::chrono::milliseconds::zero())
-            -> std::optional<Response> {
+        [[nodiscard]] auto
+        call(Request request_payload,
+             std::chrono::milliseconds timeout
+             = std::chrono::milliseconds::zero()) -> std::optional<Response> {
             auto [request_buf, request_id]
                 = make_request(std::move(request_payload));
             auto resp = call_raw(std::move(request_buf), request_id, timeout);
@@ -119,8 +119,7 @@ namespace cbdc::rpc {
 
         virtual auto call_raw(cbdc::buffer request_buf,
                               request_id_type request_id,
-                              raw_callback_type response_callback) -> bool
-            = 0;
+                              raw_callback_type response_callback) -> bool = 0;
 
         auto make_request(Request request_payload)
             -> std::pair<cbdc::buffer, request_id_type> {

--- a/src/util/rpc/format.cpp
+++ b/src/util/rpc/format.cpp
@@ -8,8 +8,8 @@
 #include "util/serialization/format.hpp"
 
 namespace cbdc {
-    auto operator<<(serializer& ser, const rpc::header& header)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const rpc::header& header) -> serializer& {
         return ser << header.m_request_id;
     }
 

--- a/src/util/rpc/format.hpp
+++ b/src/util/rpc/format.hpp
@@ -14,8 +14,8 @@ namespace cbdc {
     auto operator>>(serializer& deser, rpc::header& header) -> serializer&;
 
     template<typename T>
-    auto operator<<(serializer& ser, const rpc::request<T>& req)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const rpc::request<T>& req) -> serializer& {
         return ser << req.m_header << req.m_payload;
     }
 
@@ -25,8 +25,8 @@ namespace cbdc {
     }
 
     template<typename T>
-    auto operator<<(serializer& ser, const rpc::response<T>& resp)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const rpc::response<T>& resp) -> serializer& {
         return ser << resp.m_header << resp.m_payload;
     }
 

--- a/src/util/rpc/http/epoll_event_handler.hpp
+++ b/src/util/rpc/http/epoll_event_handler.hpp
@@ -21,8 +21,8 @@ namespace cbdc::rpc {
         auto operator=(const epoll_event_handler&)
             -> epoll_event_handler& = default;
         epoll_event_handler(epoll_event_handler&&) = default;
-        auto operator=(epoll_event_handler&&)
-            -> epoll_event_handler& = default;
+        auto
+        operator=(epoll_event_handler&&) -> epoll_event_handler& = default;
 
         /// \copydoc event_handler::init
         auto init() -> bool override;

--- a/src/util/rpc/http/json_rpc_http_client.hpp
+++ b/src/util/rpc/http/json_rpc_http_client.hpp
@@ -49,8 +49,8 @@ namespace cbdc::rpc {
         auto operator=(const json_rpc_http_client&)
             -> json_rpc_http_client& = delete;
         json_rpc_http_client(json_rpc_http_client&&) = delete;
-        auto operator=(json_rpc_http_client&&)
-            -> json_rpc_http_client& = delete;
+        auto
+        operator=(json_rpc_http_client&&) -> json_rpc_http_client& = delete;
 
         /// Type alias for the response callback function.
         using callback_type = std::function<void(std::optional<Json::Value>)>;
@@ -95,9 +95,10 @@ namespace cbdc::rpc {
 
         // size_t m_requests_started{};
 
-        static auto
-        write_data(void* ptr, size_t size, size_t nmemb, struct transfer* t)
-            -> size_t;
+        static auto write_data(void* ptr,
+                               size_t size,
+                               size_t nmemb,
+                               struct transfer* t) -> size_t;
 
         static auto socket_callback(CURL* handle,
                                     curl_socket_t s,

--- a/src/util/rpc/http/json_rpc_http_server.cpp
+++ b/src/util/rpc/http/json_rpc_http_server.cpp
@@ -145,8 +145,8 @@ namespace cbdc::rpc {
         return MHD_YES;
     }
 
-    auto json_rpc_http_server::send_cors_response(request* request_info)
-        -> bool {
+    auto
+    json_rpc_http_server::send_cors_response(request* request_info) -> bool {
         std::string response = "";
         auto* result = MHD_create_response_from_buffer(
             response.size(),

--- a/src/util/rpc/http/json_rpc_http_server.hpp
+++ b/src/util/rpc/http/json_rpc_http_server.hpp
@@ -43,8 +43,8 @@ namespace cbdc::rpc {
         auto operator=(const json_rpc_http_server&)
             -> json_rpc_http_server& = delete;
         json_rpc_http_server(json_rpc_http_server&&) = delete;
-        auto operator=(json_rpc_http_server&&)
-            -> json_rpc_http_server& = delete;
+        auto
+        operator=(json_rpc_http_server&&) -> json_rpc_http_server& = delete;
 
         /// Register the application request handler function with the server.
         void register_handler_callback(handler_callback_type handler_callback);
@@ -85,8 +85,8 @@ namespace cbdc::rpc {
                              void** con_cls) -> MHD_Result;
 
         static auto send_cors_response(request* request_info) -> bool;
-        static auto send_response(std::string response, request* request_info)
-            -> bool;
+        static auto send_response(std::string response,
+                                  request* request_info) -> bool;
 
         auto handle_request(request* request_info) -> bool;
 

--- a/src/util/rpc/server.hpp
+++ b/src/util/rpc/server.hpp
@@ -66,9 +66,9 @@ namespace cbdc::rpc {
         ///                         std::nullopt if the request failed.
         /// \return serialized response buffer.
         template<typename R = Response>
-        auto serialize_response(header request_header,
-                                std::optional<R> response_payload)
-            -> OutBuffer {
+        auto
+        serialize_response(header request_header,
+                           std::optional<R> response_payload) -> OutBuffer {
             return make_buffer<response<R>, OutBuffer>(
                 {request_header, response_payload});
         }

--- a/src/util/rpc/tcp_client.hpp
+++ b/src/util/rpc/tcp_client.hpp
@@ -68,8 +68,8 @@ namespace cbdc::rpc {
         ///                    single endpoint.
         /// \return false if there is a fatal connection error, true if the
         /// client is connected and ready and the response handler is started.
-        [[nodiscard]] auto init(std::optional<bool> error_fatal = std::nullopt)
-            -> bool {
+        [[nodiscard]] auto init(std::optional<bool> error_fatal
+                                = std::nullopt) -> bool {
             if(!error_fatal) {
                 error_fatal = m_server_endpoints.size() <= 1;
             }
@@ -149,8 +149,8 @@ namespace cbdc::rpc {
             return response_future.get();
         }
 
-        auto response_handler(network::message_t&& msg)
-            -> std::optional<buffer> {
+        auto
+        response_handler(network::message_t&& msg) -> std::optional<buffer> {
             auto resp
                 = client<Request, Response>::deserialize_response(*msg.m_pkt);
             if(resp.has_value()) {

--- a/src/util/serialization/format.hpp
+++ b/src/util/serialization/format.hpp
@@ -141,8 +141,8 @@ namespace cbdc {
     ///
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename T>
-    auto operator<<(serializer& ser, const std::optional<T>& val)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const std::optional<T>& val) -> serializer& {
         auto has_value = val.has_value();
         ser << has_value;
         if(has_value) {
@@ -183,8 +183,8 @@ namespace cbdc {
     ///
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename T>
-    auto operator<<(serializer& packet, const std::vector<T>& vec)
-        -> serializer& {
+    auto operator<<(serializer& packet,
+                    const std::vector<T>& vec) -> serializer& {
         const auto len = static_cast<uint64_t>(vec.size());
         packet << len;
         for(uint64_t i = 0; i < len; i++) {
@@ -236,9 +236,9 @@ namespace cbdc {
     /// statically-casted.
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename K, typename V, typename... Ts>
-    auto operator<<(serializer& ser,
-                    const std::unordered_map<K, V, Ts...>& map)
-        -> serializer& {
+    auto
+    operator<<(serializer& ser,
+               const std::unordered_map<K, V, Ts...>& map) -> serializer& {
         auto len = static_cast<uint64_t>(map.size());
         ser << len;
         for(const auto& it : map) {
@@ -251,8 +251,8 @@ namespace cbdc {
     /// Deserializes an unordered map of key-value pairs.
     /// \see \ref cbdc::operator<<(serializer&, const std::unordered_map<K, V, Ts...>&)
     template<typename K, typename V, typename... Ts>
-    auto operator>>(serializer& deser, std::unordered_map<K, V, Ts...>& map)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    std::unordered_map<K, V, Ts...>& map) -> serializer& {
         static_assert(sizeof(K) + sizeof(V) <= config::maximum_reservation,
                       "Unordered Map element size too large");
         auto len = uint64_t();
@@ -287,8 +287,8 @@ namespace cbdc {
     /// Serializes the count of items, and then each item statically-casted.
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename K, typename... Ts>
-    auto operator<<(serializer& ser, const std::set<K, Ts...>& set)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const std::set<K, Ts...>& set) -> serializer& {
         auto len = static_cast<uint64_t>(set.size());
         ser << len;
         for(const auto& key : set) {
@@ -300,8 +300,8 @@ namespace cbdc {
     /// Deserializes a set of items.
     /// \see \ref cbdc::operator<<(serializer&, const std::set<K, Ts...>&)
     template<typename K, typename... Ts>
-    auto operator>>(serializer& deser, std::set<K, Ts...>& set)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    std::set<K, Ts...>& set) -> serializer& {
         auto len = uint64_t();
         if(!(deser >> len)) {
             return deser;
@@ -320,8 +320,8 @@ namespace cbdc {
     /// Serializes the count of items, and then each item statically-casted.
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename K, typename... Ts>
-    auto operator<<(serializer& ser, const std::unordered_set<K, Ts...>& set)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const std::unordered_set<K, Ts...>& set) -> serializer& {
         auto len = static_cast<uint64_t>(set.size());
         ser << len;
         for(const auto& key : set) {
@@ -333,8 +333,8 @@ namespace cbdc {
     /// Deserializes an unordered set of items.
     /// \see \ref cbdc::operator<<(serializer&, const std::unordered_set<K, Ts...>&)
     template<typename K, typename... Ts>
-    auto operator>>(serializer& deser, std::unordered_set<K, Ts...>& set)
-        -> serializer& {
+    auto operator>>(serializer& deser,
+                    std::unordered_set<K, Ts...>& set) -> serializer& {
         static_assert(sizeof(K) <= config::maximum_reservation,
                       "Unordered Set element size too large");
         auto len = uint64_t();
@@ -361,12 +361,12 @@ namespace cbdc {
     /// Serializes the variant index of the value, and then the value itself.
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename... Ts>
-    auto operator<<(serializer& ser, const std::variant<Ts...>& var)
-        -> serializer& {
+    auto operator<<(serializer& ser,
+                    const std::variant<Ts...>& var) -> serializer& {
         using S = uint8_t;
         static_assert(
-            std::variant_size_v<std::remove_reference_t<decltype(var)>> < std::
-                numeric_limits<S>::max());
+            std::variant_size_v<std::remove_reference_t<decltype(var)>>
+            < std::numeric_limits<S>::max());
         auto idx = static_cast<S>(var.index());
         ser << idx;
         std::visit(
@@ -385,8 +385,8 @@ namespace cbdc {
                             serializer&> {
         using S = uint8_t;
         static_assert(
-            std::variant_size_v<std::remove_reference_t<decltype(var)>> < std::
-                numeric_limits<S>::max());
+            std::variant_size_v<std::remove_reference_t<decltype(var)>>
+            < std::numeric_limits<S>::max());
         S idx{};
         deser >> idx;
         auto var_idx = static_cast<size_t>(idx);

--- a/src/util/serialization/istream_serializer.cpp
+++ b/src/util/serialization/istream_serializer.cpp
@@ -32,8 +32,8 @@ namespace cbdc {
         m_str.seekg(0);
     }
 
-    auto istream_serializer::write(const void* /* data */, size_t /* len */)
-        -> bool {
+    auto istream_serializer::write(const void* /* data */,
+                                   size_t /* len */) -> bool {
         m_str.setstate(std::ios::failbit);
         return false;
     }

--- a/tests/integration/sample_erc20_contract.cpp
+++ b/tests/integration/sample_erc20_contract.cpp
@@ -190,8 +190,8 @@ namespace cbdc::test::evm_contracts {
         return buf.value();
     }
 
-    auto data_erc20_allowance(evmc::address owner, evmc::address spender)
-        -> cbdc::buffer {
+    auto data_erc20_allowance(evmc::address owner,
+                              evmc::address spender) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_allowance
             = std::string("allowance(address,address)");
@@ -205,8 +205,8 @@ namespace cbdc::test::evm_contracts {
         return buf;
     }
 
-    auto data_erc20_approve(evmc::address spender, evmc::uint256be amount)
-        -> cbdc::buffer {
+    auto data_erc20_approve(evmc::address spender,
+                            evmc::uint256be amount) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_approve = std::string("approve(address,uint256)");
         auto selector_hash = cbdc::keccak_data(selector_approve.data(),
@@ -297,8 +297,8 @@ namespace cbdc::test::evm_contracts {
         return buf;
     }
 
-    auto data_erc20_transfer(evmc::address to, evmc::uint256be amount)
-        -> cbdc::buffer {
+    auto data_erc20_transfer(evmc::address to,
+                             evmc::uint256be amount) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_transfer
             = std::string("transfer(address,uint256)");

--- a/tests/integration/sample_erc20_contract.hpp
+++ b/tests/integration/sample_erc20_contract.hpp
@@ -34,11 +34,11 @@ namespace cbdc::test::evm_contracts {
         = 12; // in ABIs addresses are also 32 bytes
     auto data_erc20_contract_bytecode() -> cbdc::buffer;
 
-    auto data_erc20_allowance(evmc::address owner, evmc::address spender)
-        -> cbdc::buffer;
+    auto data_erc20_allowance(evmc::address owner,
+                              evmc::address spender) -> cbdc::buffer;
 
-    auto data_erc20_approve(evmc::address spender, evmc::uint256be amount)
-        -> cbdc::buffer;
+    auto data_erc20_approve(evmc::address spender,
+                            evmc::uint256be amount) -> cbdc::buffer;
 
     auto data_erc20_balance_of(evmc::address account) -> cbdc::buffer;
 
@@ -48,9 +48,9 @@ namespace cbdc::test::evm_contracts {
                                        evmc::uint256be subtracted_value)
         -> cbdc::buffer;
 
-    auto data_erc20_increase_allowance(evmc::address spender,
-                                       evmc::uint256be added_value)
-        -> cbdc::buffer;
+    auto
+    data_erc20_increase_allowance(evmc::address spender,
+                                  evmc::uint256be added_value) -> cbdc::buffer;
 
     auto data_erc20_name() -> cbdc::buffer;
 
@@ -58,8 +58,8 @@ namespace cbdc::test::evm_contracts {
 
     auto data_erc20_total_supply() -> cbdc::buffer;
 
-    auto data_erc20_transfer(evmc::address to, evmc::uint256be amount)
-        -> cbdc::buffer;
+    auto data_erc20_transfer(evmc::address to,
+                             evmc::uint256be amount) -> cbdc::buffer;
 
     auto data_erc20_transfer_from(evmc::address from,
                                   evmc::address to,

--- a/tests/util.hpp
+++ b/tests/util.hpp
@@ -30,15 +30,15 @@ namespace cbdc::test {
     /// Allows hashing \ref compact_transaction s (e.g., for storing them
     /// in a std::unordered_set
     struct compact_transaction_hasher {
-        auto operator()(const compact_transaction& tx) const noexcept
-            -> size_t;
+        auto
+        operator()(const compact_transaction& tx) const noexcept -> size_t;
     };
 
     /// Specialization of Block to allow transactions to be compared as
     /// cbdc::test::compact_transactions.
     struct block : cbdc::atomizer::block {
-        auto operator==(const cbdc::atomizer::block& tx) const noexcept
-            -> bool;
+        auto
+        operator==(const cbdc::atomizer::block& tx) const noexcept -> bool;
     };
 
     /// Maintains a connection to the specified set of endpoints and provides a
@@ -60,8 +60,8 @@ namespace cbdc::test {
         /// Connect to the specified endpoints.
         /// \param endpoints to which to connect.
         /// \return false if any connections failed.
-        auto connect(const std::vector<network::endpoint_t>& endpoints)
-            -> bool {
+        auto
+        connect(const std::vector<network::endpoint_t>& endpoints) -> bool {
             if constexpr(std::is_same_v<std::decay_t<T>, std::nullopt_t>) {
                 return m_client_net.cluster_connect(endpoints, true);
             } else {

--- a/tools/bench/parsec/evm/contracts.cpp
+++ b/tools/bench/parsec/evm/contracts.cpp
@@ -190,8 +190,8 @@ namespace cbdc::parsec::evm_contracts {
         return buf.value();
     }
 
-    auto data_erc20_allowance(evmc::address owner, evmc::address spender)
-        -> cbdc::buffer {
+    auto data_erc20_allowance(evmc::address owner,
+                              evmc::address spender) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_allowance
             = std::string("allowance(address,address)");
@@ -205,8 +205,8 @@ namespace cbdc::parsec::evm_contracts {
         return buf;
     }
 
-    auto data_erc20_approve(evmc::address spender, evmc::uint256be amount)
-        -> cbdc::buffer {
+    auto data_erc20_approve(evmc::address spender,
+                            evmc::uint256be amount) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_approve = std::string("approve(address,uint256)");
         auto selector_hash = cbdc::keccak_data(selector_approve.data(),
@@ -297,8 +297,8 @@ namespace cbdc::parsec::evm_contracts {
         return buf;
     }
 
-    auto data_erc20_transfer(evmc::address to, evmc::uint256be amount)
-        -> cbdc::buffer {
+    auto data_erc20_transfer(evmc::address to,
+                             evmc::uint256be amount) -> cbdc::buffer {
         auto buf = cbdc::buffer();
         const auto selector_transfer
             = std::string("transfer(address,uint256)");

--- a/tools/bench/parsec/evm/contracts.hpp
+++ b/tools/bench/parsec/evm/contracts.hpp
@@ -19,11 +19,11 @@ namespace cbdc::parsec::evm_contracts {
         = 12; // in ABIs addresses are also 32 bytes
     auto data_erc20_deploy() -> cbdc::buffer;
 
-    auto data_erc20_allowance(evmc::address owner, evmc::address spender)
-        -> cbdc::buffer;
+    auto data_erc20_allowance(evmc::address owner,
+                              evmc::address spender) -> cbdc::buffer;
 
-    auto data_erc20_approve(evmc::address spender, evmc::uint256be amount)
-        -> cbdc::buffer;
+    auto data_erc20_approve(evmc::address spender,
+                            evmc::uint256be amount) -> cbdc::buffer;
 
     auto data_erc20_balance_of(evmc::address account) -> cbdc::buffer;
 
@@ -33,9 +33,9 @@ namespace cbdc::parsec::evm_contracts {
                                        evmc::uint256be subtracted_value)
         -> cbdc::buffer;
 
-    auto data_erc20_increase_allowance(evmc::address spender,
-                                       evmc::uint256be added_value)
-        -> cbdc::buffer;
+    auto
+    data_erc20_increase_allowance(evmc::address spender,
+                                  evmc::uint256be added_value) -> cbdc::buffer;
 
     auto data_erc20_name() -> cbdc::buffer;
 
@@ -43,8 +43,8 @@ namespace cbdc::parsec::evm_contracts {
 
     auto data_erc20_total_supply() -> cbdc::buffer;
 
-    auto data_erc20_transfer(evmc::address to, evmc::uint256be amount)
-        -> cbdc::buffer;
+    auto data_erc20_transfer(evmc::address to,
+                             evmc::uint256be amount) -> cbdc::buffer;
 
     auto data_erc20_transfer_from(evmc::address from,
                                   evmc::address to,

--- a/tools/bench/parsec/evm/evm_bench.cpp
+++ b/tools/bench/parsec/evm/evm_bench.cpp
@@ -75,8 +75,8 @@ auto evm_bench::gen_tx(evmc::uint256be nonce,
     return tx_hex;
 }
 
-auto evm_bench::deploy_erc20(evmc::uint256be nonce, cbdc::privkey_t skey)
-    -> std::string {
+auto evm_bench::deploy_erc20(evmc::uint256be nonce,
+                             cbdc::privkey_t skey) -> std::string {
     auto tx = cbdc::parsec::agent::runner::evm_tx();
     tx.m_gas_limit = evmc::uint256be(0xffffffff);
     tx.m_gas_price = evmc::uint256be(0);

--- a/tools/bench/parsec/evm/evm_bench.hpp
+++ b/tools/bench/parsec/evm/evm_bench.hpp
@@ -102,8 +102,8 @@ class evm_bench {
                 cbdc::privkey_t skey,
                 evmc::uint256be value) -> std::string;
 
-    auto deploy_erc20(evmc::uint256be nonce, cbdc::privkey_t skey)
-        -> std::string;
+    auto deploy_erc20(evmc::uint256be nonce,
+                      cbdc::privkey_t skey) -> std::string;
 
     auto send_erc20(evmc::address erc20_addr,
                     evmc::uint256be nonce,

--- a/tools/bench/parsec/lua/wallet.hpp
+++ b/tools/bench/parsec/lua/wallet.hpp
@@ -80,8 +80,8 @@ namespace cbdc::parsec {
             m_secp{secp256k1_context_create(SECP256K1_CONTEXT_SIGN),
                    &secp256k1_context_destroy};
 
-        [[nodiscard]] auto make_pay_params(pubkey_t to, uint64_t amount) const
-            -> cbdc::buffer;
+        [[nodiscard]] auto
+        make_pay_params(pubkey_t to, uint64_t amount) const -> cbdc::buffer;
 
         auto execute_params(cbdc::buffer params,
                             bool dry_run,


### PR DESCRIPTION
PR described in #293
[WIP]
This will lead to far less clang style errors vs before (so faster CI/CD lint stage) and prettier code.

We could consider splitting the lint github workflow stage into just style checks (newline/whitespace/format) separate from the clang tidy check which is more intensive and about C++ 20 features. Open to discussion.

The script is minimal, and I added it as a bare-bones version, but if we like this, I can optimize it to be more robust.


Edit: clang18 was the linked version in mac/homebrew so I had to override that.
```console
brew uninstall --ignore-dependencies llvm
brew [re]install llvm@14

~/.zshrc
export PATH="/usr/local/opt/llvm@14/bin:$PATH"
LDFLAGS="-L/opt/homebrew/opt/llvm@14/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm@14/lib/c++"
export LDFLAGS="-L/opt/homebrew/opt/llvm@14/lib"
export CPPFLAGS="-I/opt/homebrew/opt/llvm@14/include"
```