### PR TITLE
ci: updating the uses tag version in gh actions jobs; #288

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       BUILD_RELEASE: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -35,7 +35,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -55,11 +55,11 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Build Env
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Build Env
@@ -85,7 +85,7 @@ jobs:
       - name: Shorten SHA
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ !env.ACT }}
         name: Archive Test Results
         with:
@@ -98,7 +98,7 @@ jobs:
     name: doxygen
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Doxygen
@@ -109,7 +109,7 @@ jobs:
         run: doxygen Doxyfile
       - name: Upload Docs artifacts
         if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: OpenCBDC Transaction Processor docs for ${{ steps.vars.outputs.sha_short }}
           path: ./doxygen_generated/html/*

--- a/.github/workflows/docker-merge.yml
+++ b/.github/workflows/docker-merge.yml
@@ -5,7 +5,7 @@ name: docker merge
 on:
   push:
     branches:
-      - 'trunk'
+      - trunk
 
 jobs:
   docker-build:
@@ -15,14 +15,14 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ########################
       # Build Base           #
       ########################
       - name: Docker meta base (merge)
         id: meta-base
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -35,20 +35,20 @@ jobs:
             type=sha
 
       - name: Set up QEMU (merge)
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx (merge)
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry (merge)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: base
@@ -69,7 +69,7 @@ jobs:
       ########################
       - name: Docker meta twophase (merge)
         id: meta-twophase
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Docker meta atomizer (merge)
         id: meta-atomizer
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -97,7 +97,7 @@ jobs:
 
       - name: Docker meta parsec (merge)
         id: meta-parsec
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -111,7 +111,7 @@ jobs:
 
 
       - name: Build and push twophase (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: twophase
@@ -122,7 +122,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push atomizer (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: atomizer
@@ -133,7 +133,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push parsec (merge)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: parsec

--- a/.github/workflows/docker-pull.yml
+++ b/.github/workflows/docker-pull.yml
@@ -15,14 +15,14 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: "2"
 
       # For PRs, this action compares between the commit and trunk
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             Dockerfile

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -7,7 +7,7 @@ name: docker push
 on:
   push:
     branches-ignore:
-      - 'trunk'
+      - trunk
 
 jobs:
   docker-build:
@@ -17,7 +17,7 @@ jobs:
       # CI Setup             #
       ########################
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       ########################
       # Build Base           #

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0


### PR DESCRIPTION
debugging docker merge/pull/push and updating the '@ v#' versions within `.github/workflows/*` as some of them had gotten old / stale (see screenshot below)

**stage speedups!** vs other PRs in queue
- doxygen: {before: 3 min 47 sec, now: 44 sec}
- docker pull_request / docker-build {before: 4 min 1 sec, now: 3 min 24 sec}
- CI / Build Release Candidate {before: 5 min 24 sec, now: 5 min 4 sec}
- CI / Unit and Integration Tests {before: 17 min 14 sec, now: 15 min 59 sec}
- CI / Lint {before: 21 min 33 sec, now: 20 min 36 sec}

<img width="1639" alt="gh warnings" src="https://github.com/user-attachments/assets/685feb60-7f25-46fc-8993-b66126855e6f">
