### PR TITLE
fix evmone version

### DIFF
--- a/scripts/setup-dependencies.sh
+++ b/scripts/setup-dependencies.sh
@@ -105,7 +105,7 @@ cd ../..
 
 # NOTE: evmc v10.0.0 requires evmone v0.9.0
 #       evmc v10.1.1 requires evmone v0.10.0 (which requires c++20)
-EVMC_VER=10.0.0
+EVMC_VER=11.0.1
 wget https://github.com/ethereum/evmc/archive/refs/tags/v${EVMC_VER}.zip
 rm -rf evmc-${EVMC_VER}
 unzip v${EVMC_VER}.zip
@@ -119,7 +119,7 @@ make install
 cd ../..
 
 # NOTE: updating evmone to v0.10.0 requires c++20
-EVMONE_VER=0.9.1
+EVMONE_VER=0.11.0
 wget https://github.com/ethereum/evmone/archive/refs/tags/v${EVMONE_VER}.zip
 rm -rf evmone-${EVMONE_VER}
 unzip v${EVMONE_VER}.zip

--- a/src/parsec/agent/runners/evm/host.cpp
+++ b/src/parsec/agent/runners/evm/host.cpp
@@ -36,6 +36,17 @@ namespace cbdc::parsec::agent::runner {
         m_receipt.m_ticket_number = m_ticket_number;
     }
 
+    // implementation for the get_transient_storage method
+    evmc::bytes32 evm_host::get_transient_storage([[maybe_unused]] const evmc::address& addr,
+                [[maybe_unused]] const evmc::bytes32& key) const noexcept {
+        return evmc::bytes32{};
+    }
+
+    // implementation for the set_trainsient_storage method
+    void evm_host::set_transient_storage([[maybe_unused]] const evmc::address& addr, [[maybe_unused]] const evmc::bytes32& key, [[maybe_unused]]  const evmc::bytes32& value) noexcept {
+        
+    }
+
     auto evm_host::get_account(const evmc::address& addr, bool write) const
         -> std::optional<evm_account> {
         m_log->trace(this,

--- a/src/parsec/agent/runners/evm/host.hpp
+++ b/src/parsec/agent/runners/evm/host.hpp
@@ -97,6 +97,14 @@ namespace cbdc::parsec::agent::runner {
                             const evmc::bytes32& key) noexcept
             -> evmc_access_status override final;
 
+        // method signature for get_transient_storage
+        [[nodiscard]] auto get_transient_storage(const evmc::address& address,
+            const evmc::bytes32& key) const noexcept -> evmc::bytes32 override final;
+
+        // method signature for the set_transient_storage
+        void set_transient_storage(const evmc::address& address, const evmc::bytes32& key,
+            const evmc::bytes32& value) noexcept override final;
+
         using indexed_logs_type
             = std::unordered_map<evmc::address, std::vector<evm_log>>;
 


### PR DESCRIPTION
This PR addresses issue #275 by pinning the installation to a specific version.

Both [EVMONE](https://github.com/ethereum/evmone/releases/tag/v0.11.0) and [EVMC](https://github.com/ethereum/evmc/releases/tag/v11.0.1) are upgraded to "Cancun" versions 0.11.0 and 11.0.1 respectively. This upgrade prevents an error where EVMONE fails to build and the Hunter install subsequently gets stuck when running the `setup-dependencies.sh` on a MacBook M3 Max running Sonoma 14.5.

Tested: tested by running `./scripts/setup-dependencies.sh` and verified that the Hunter install does not hang.