### PR TITLE
upgrade: Upgrade nuraft to 2.1.0

### DIFF
--- a/scripts/setup-dependencies.sh
+++ b/scripts/setup-dependencies.sh
@@ -39,7 +39,7 @@ make -j$CPUS
 make install
 cd ..
 
-NURAFT_VERSION="1.3.0"
+NURAFT_VERSION="2.1.0"
 echo -e "${green}Building NuRaft from sources...${end}"
 wget https://github.com/eBay/NuRaft/archive/v${NURAFT_VERSION}.tar.gz
 rm -rf "NuRaft-${NURAFT_VERSION}-${CMAKE_BUILD_TYPE}"

--- a/tests/unit/raft_test.cpp
+++ b/tests/unit/raft_test.cpp
@@ -173,6 +173,10 @@ class raft_test : public ::testing::Test {
         auto new_log
             = cbdc::make_buffer<uint64_t, nuraft::ptr<nuraft::buffer>>(1);
 
+        auto res = nodes[0]->replicate_sync(new_log);
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(nodes[0]->last_log_idx(), 2UL);
+
         cbdc::raft::callback_type result_fn = nullptr;
         auto result_done = std::atomic<bool>(false);
         if(!blocking) {
@@ -190,14 +194,7 @@ class raft_test : public ::testing::Test {
         while(!result_done) {
             std::this_thread::sleep_for(std::chrono::milliseconds(250));
         }
-        ASSERT_EQ(nodes[0]->last_log_idx(), 2UL);
-
-        if(blocking) {
-            // Replicate sync will only return a value in the blocking context
-            auto res = nodes[0]->replicate_sync(new_log);
-            ASSERT_TRUE(res.has_value());
-            ASSERT_EQ(nodes[0]->last_log_idx(), 3UL);
-        }
+        ASSERT_EQ(nodes[0]->last_log_idx(), 3UL);
 
         for(size_t i{0}; i < nodes.size(); i++) {
             ASSERT_EQ(nodes[i]->get_sm(), sms[i].get());


### PR DESCRIPTION
Upgrades NuRaft to v2.1.0. 

This upgrade caused a failing assertion in the `raft_node_test_non_blocking` unit test. I claim that this assertion in the non_blocking test was actually misguided, and as written, should have always failed in the non_blocking context (or more accurately, the assertion gave insufficient information about whether the task completed correctly). 

This test fails because when getting the result code of a replication which is asynchronous, if the result has not been written yet, the return value is not cmd_result_code::OK (it becomes `cmd_result_code::RESULT_NOT_EXIST_YET`). In the non-blocking context, this should not prompt a failure, specifically with `node::replicate_sync` written as it is currently. The reason this does not fail with v1.3 is because `cmd_result_code::RESULT_NOT_EXIST_YET` did not exist, and `get_result_code()` returned the default value of `cmd_result_code`, which appeared to be `cmd_result_code::OK`. 

Would appreciate feedback about whether we should re-write `replicate_sync` to be blocking in a non-blocking node, and wait to see if the result code is truly OK before proceeding. It does not seem like this has been the case to this point (but I have a hunch that it should be), but happy to be wrong on this point. This change is not included in this PR at the time of writing.