### PR TITLE
chore: fix some warnings on clang 16.0.0

### DIFF
--- a/tests/unit/rpc/tcp_test.cpp
+++ b/tests/unit/rpc/tcp_test.cpp
@@ -175,14 +175,14 @@ TEST(tcp_rpc_test, async_echo_test) {
     server.register_handler_callback(
         [](request req,
            std::function<void(std::optional<response>)> cb) -> bool {
-            std::thread([cb = std::move(cb), r = req]() {
+            std::thread([cb_inner = std::move(cb), r = req]() {
                 auto resp = response{};
                 std::visit(
                     [&](auto val) {
                         resp = val;
                     },
                     r);
-                cb(resp);
+                cb_inner(resp);
             }).detach();
             return true;
         });
@@ -229,8 +229,8 @@ TEST(tcp_rpc_test, async_error_test) {
         [](request req,
            std::function<void(std::optional<response>)> cb) -> bool {
             if(req) {
-                std::thread([cb = std::move(cb)]() {
-                    cb(std::nullopt);
+                std::thread([cb_inner = std::move(cb)]() {
+                    cb_inner(std::nullopt);
                 }).detach();
             }
             return req;

--- a/tools/bench/twophase_gen.cpp
+++ b/tools/bench/twophase_gen.cpp
@@ -242,7 +242,7 @@ auto main(int argc, char** argv) -> int {
                                  .count();
 
             auto res_cb
-                = [&, txn = tx.value(), send_time = send_time](
+                = [&, txn = tx.value(), send_time](
                       cbdc::sentinel::rpc::client::execute_result_type res) {
                       auto tx_id = cbdc::transaction::tx_id(txn);
                       if(!res.has_value()) {


### PR DESCRIPTION
Addresses three minor "shadow-uncaptured-local" warnings. Noticed that these are raised by Clang 16.0.0 which prevents compilation with -Werror. Minor QOL change for users of Clang 16.0.0