### PR TITLE
fix: makes parsec endpoint names scalable; fixes #312

### DIFF
--- a/docker-compose-parsec-test.yml
+++ b/docker-compose-parsec-test.yml
@@ -9,7 +9,7 @@ services:
     image: opencbdc-tx-parsec
     platform: linux/amd64
     tty: true
-    command: ./scripts/wait-for-it.sh -s agent0:8080 -t 60 -- ./build/tools/bench/parsec/evm/evm_bench --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loadgen_accounts=8192 --loadgen_txtype=erc20 --telemetry=1
+    command: ./scripts/wait-for-it.sh -s agent0:8080 -t 60 -- ./build/tools/bench/parsec/evm/evm_bench --shard_count=1 --shard0_count=1 --shard0_0_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loadgen_accounts=8192 --loadgen_txtype=erc20 --telemetry=1
     networks:
       - parsec-network
     healthcheck:

--- a/docker-compose-parsec.yml
+++ b/docker-compose-parsec.yml
@@ -10,7 +10,7 @@ services:
     platform: linux/amd64
     tty: true
     restart: always
-    command: ./scripts/wait-for-it.sh -s ticket0:7777 -t 60 -- ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/agent/agentd --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN --runner_type="evm"
+    command: ./scripts/wait-for-it.sh -s ticket0:7777 -t 60 -- ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/agent/agentd --shard_count=1 --shard0_count=1 --shard0_0_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:8080 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN --runner_type="evm"
     ports:
       - 8080:8080
     networks:
@@ -28,7 +28,7 @@ services:
     image: opencbdc-tx-parsec
     platform: linux/amd64
     tty: true
-    command: ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/ticket_machine/ticket_machined --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
+    command: ./scripts/wait-for-it.sh -s shard0:5556 -t 60 -- ./build/src/parsec/ticket_machine/ticket_machined --shard_count=1 --shard0_count=1 --shard0_0_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
     networks:
       - parsec-network
     healthcheck:
@@ -45,7 +45,7 @@ services:
     image: opencbdc-tx-parsec
     platform: linux/amd64
     tty: true
-    command: ./build/src/parsec/runtime_locking_shard/runtime_locking_shardd --shard_count=1 --shard0_count=1 --shard00_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
+    command: ./build/src/parsec/runtime_locking_shard/runtime_locking_shardd --shard_count=1 --shard0_count=1 --shard0_0_endpoint=shard0:5556 --node_id=0 --component_id=0 --agent_count=1 --agent0_endpoint=agent0:6666 --ticket_machine_count=1 --ticket_machine0_endpoint=ticket0:7777 --loglevel=WARN
     networks:
       - parsec-network
     healthcheck:

--- a/scripts/lua_bench.sh
+++ b/scripts/lua_bench.sh
@@ -30,7 +30,7 @@ for arg in "$@"; do
 done
 ./build/tools/bench/parsec/lua/lua_bench --component_id=0 \
     --ticket_machine0_endpoint=$IP:7777 --ticket_machine_count=1 \
-    --shard_count=1 --shard0_count=1 --shard00_endpoint=$IP:5556 \
+    --shard_count=1 --shard0_count=1 --shard0_0_endpoint=$IP:5556 \
     --agent_count=1 --agent0_endpoint=$IP:$PORT \
     --loglevel=$LOGLEVEL scripts/gen_bytecode.lua $N_WALLETS
 echo done

--- a/scripts/parsec-run-local.sh
+++ b/scripts/parsec-run-local.sh
@@ -41,23 +41,26 @@ echo Running agent on $IP:$PORT
 echo Log level = $LOGLEVEL
 echo Runner type = $RUNNER_TYPE
 
-./build/src/parsec/runtime_locking_shard/runtime_locking_shardd --shard_count=1 \
-    --shard0_count=1 --shard00_endpoint=$IP:5556 \
-    --shard00_raft_endpoint=$IP:5557 --node_id=0 --component_id=0 \
-    --agent_count=1 --agent0_endpoint=$IP:6666 --ticket_machine_count=1 \
-    --ticket_machine0_endpoint=$IP:7777 --loglevel=$LOGLEVEL \
-    > logs/shardd.log &
+./build/src/parsec/runtime_locking_shard/runtime_locking_shardd \
+    --shard_count=1 --shard0_count=1 --shard0_0_endpoint=$IP:5556 \
+    --node_id=0 --component_id=0 \
+    --agent_count=1 --agent0_endpoint=$IP:6666 \
+    --ticket_machine_count=1 --ticket_machine0_endpoint=$IP:7777 \
+    --loglevel=$LOGLEVEL > logs/shardd.log &
 sleep 1
 ./scripts/wait-for-it.sh -s $IP:5556 -t 60 -- \
-    ./build/src/parsec/ticket_machine/ticket_machined --shard_count=1 \
-    --shard0_count=1 --shard00_endpoint=$IP:5556 --node_id=0 \
-    --component_id=0 --agent_count=1 --agent0_endpoint=$IP:6666 \
+    ./build/src/parsec/ticket_machine/ticket_machined \
+    --shard_count=1 --shard0_count=1 --shard0_0_endpoint=$IP:5556 \
+    --node_id=0 --component_id=0 \
+    --agent_count=1 --agent0_endpoint=$IP:6666 \
     --ticket_machine_count=1 --ticket_machine0_endpoint=$IP:7777 \
     --loglevel=$LOGLEVEL > logs/ticket_machined.log &
 sleep 1
-./scripts/wait-for-it.sh -s $IP:7777 -t 60 -- ./scripts/wait-for-it.sh -s \
-    $IP:5556 -t 60 -- ./build/src/parsec/agent/agentd --shard_count=1 \
-    --shard0_count=1 --shard00_endpoint=$IP:5556 --node_id=0 --component_id=0 \
-    --agent_count=1 --agent0_endpoint=$IP:$PORT --ticket_machine_count=1 \
-    --ticket_machine0_endpoint=$IP:7777 --loglevel=$LOGLEVEL \
-    --runner_type=$RUNNER_TYPE > logs/agentd.log &
+./scripts/wait-for-it.sh -s $IP:7777 -t 60 -- \
+    ./scripts/wait-for-it.sh -s $IP:5556 -t 60 -- \
+    ./build/src/parsec/agent/agentd \
+    --shard_count=1 --shard0_count=1 --shard0_0_endpoint=$IP:5556 \
+    --node_id=0 --component_id=0 \
+    --agent_count=1 --agent0_endpoint=$IP:$PORT \
+    --ticket_machine_count=1 --ticket_machine0_endpoint=$IP:7777 \
+    --loglevel=$LOGLEVEL --runner_type=$RUNNER_TYPE > logs/agentd.log &

--- a/src/parsec/util.cpp
+++ b/src/parsec/util.cpp
@@ -60,7 +60,13 @@ namespace cbdc::parsec {
         auto count = std::stoull(it->second);
 
         for(size_t i = 0; i < count; i++) {
-            auto ep_key = component_name + std::to_string(i) + "_endpoint";
+            auto ep_key = component_name;
+            // shard(\d)_count -> shard(\d)_(\d)_endpoint
+            const std::string shard_ep = "shard";
+            if(component_name.find(shard_ep) == 0) {
+                ep_key += "_";
+            }
+            ep_key += std::to_string(i) + "_endpoint";
             it = opts.find(ep_key);
             if(it == opts.end()) {
                 return std::nullopt;


### PR DESCRIPTION
Before: `shard##_endpoint`
After:     `shard#_#_endpoint`

This PR let's parsec use the same naming convention as 2pc for shard endpoints.

Also, credit to @madars for pointing out the unnecessary `--shard00_raft_endpoint=$IP:5557`.
https://github.com/mit-dci/opencbdc-tx/blob/96062b5b9a3cd9406ea4e0174829be8d0e80f18a/scripts/parsec-run-local.sh#L46
That could be a separate commit or PR based on reviewer discretion